### PR TITLE
Format files with phpcbf command

### DIFF
--- a/CRM/Civalpa/Config.php
+++ b/CRM/Civalpa/Config.php
@@ -1,6 +1,7 @@
 <?php
 
-class CRM_Civalpa_Config {
+class CRM_Civalpa_Config
+{
     const DEFAULT_TEXT_LINE_WIDTH = 990;
     const DEFAULT_HTML_LINE_WIDTH = 990;
 
@@ -12,7 +13,8 @@ class CRM_Civalpa_Config {
      *
      * @param string $extensionName prefix for db.
      */
-    public function __construct(string $extensionName) {
+    public function __construct(string $extensionName)
+    {
         $this->configName = $extensionName."_rules";
         $this->configuration = $this->defaultConfiguration();
     }
@@ -22,7 +24,8 @@ class CRM_Civalpa_Config {
      *
      * @return array the default configuration object.
      */
-    private function defaultConfiguration(): array {
+    private function defaultConfiguration(): array
+    {
         return [
             "debug-mode" => true,
             "text-line-width" => [
@@ -41,7 +44,8 @@ class CRM_Civalpa_Config {
      *
      * @return bool the status of the db write process.
      */
-    public function create(): bool {
+    public function create(): bool
+    {
         Civi::settings()->add([$this->configName => $this->configuration]);
         // check the save process with loading the saved content and compare
         // it with the current configuration
@@ -54,7 +58,8 @@ class CRM_Civalpa_Config {
      *
      * @return bool the status of the deletion process.
      */
-    public function remove(): bool {
+    public function remove(): bool
+    {
         Civi::settings()->revert($this->configName);
         // check the deletion process with loading the saved content and compare
         // it with null.
@@ -72,7 +77,8 @@ class CRM_Civalpa_Config {
      *
      * @throws CRM_Core_Exception.
      */
-    public function load(): void {
+    public function load(): void
+    {
         $conf = Civi::settings()->get($this->configName);
         // if not loaded well, it throws exception.
         if (is_null($conf) || !is_array($conf)) {
@@ -88,7 +94,8 @@ class CRM_Civalpa_Config {
      *
      * @return bool the status of the update process.
      */
-    public function update(array $newConfig): bool {
+    public function update(array $newConfig): bool
+    {
         Civi::settings()->set($this->configName, $newConfig);
         // check the save process with loading the saved content and compare
         // it with the newConfig configuration
@@ -107,7 +114,8 @@ class CRM_Civalpa_Config {
      *
      * @throws CRM_Core_Exception.
      */
-    public function get(): array {
+    public function get(): array
+    {
         if (is_null($this->configuration)) {
             throw new CRM_Core_Exception($this->configName." config is missing.");
         }

--- a/CRM/Civalpa/Form/CivalpaSettings.php
+++ b/CRM/Civalpa/Form/CivalpaSettings.php
@@ -7,7 +7,8 @@ use CRM_Civalpa_ExtensionUtil as E;
  *
  * @see https://docs.civicrm.org/dev/en/latest/framework/quickform/
  */
-class CRM_Civalpa_Form_CivalpaSettings extends CRM_Core_Form {
+class CRM_Civalpa_Form_CivalpaSettings extends CRM_Core_Form
+{
 
     /**
      * Configdb
@@ -22,13 +23,15 @@ class CRM_Civalpa_Form_CivalpaSettings extends CRM_Core_Form {
      *
      * @throws CRM_Core_Exception
      */
-    public function preProcess() {
+    public function preProcess()
+    {
         // Get current settings
         $this->config = new CRM_Civalpa_Config(E::SHORT_NAME);
         $this->config->load();
     }
 
-    public function buildQuickForm() {
+    public function buildQuickForm()
+    {
 
         // get the current configuration object
         $config = $this->config->get();
@@ -76,7 +79,8 @@ class CRM_Civalpa_Form_CivalpaSettings extends CRM_Core_Form {
     /**
      * If your form requires special validation, add one or more callbacks here
      */
-    public function addRules() {
+    public function addRules()
+    {
         $this->addFormRule(array('CRM_Civalpa_Form_CivalpaSettings', 'configValidator'));
     }
 
@@ -87,7 +91,8 @@ class CRM_Civalpa_Form_CivalpaSettings extends CRM_Core_Form {
      *
      * @return array|bool
      */
-    public function configValidator($values) {
+    public function configValidator($values)
+    {
         $errors = [];
         if (!is_numeric($values["textLineWidth"]) || intval($values["textLineWidth"], 10) < 1) {
             $errors["textLineWidth"] = ts("Only positiv integer values allowed.");
@@ -103,7 +108,8 @@ class CRM_Civalpa_Form_CivalpaSettings extends CRM_Core_Form {
      *
      * @throws CRM_Core_Exception
      */
-    public function postProcess() {
+    public function postProcess()
+    {
         $newConfig = [
             "debug-mode" => $this->_submitValues["debugMode"],
             "text-line-width" => [
@@ -133,7 +139,8 @@ class CRM_Civalpa_Form_CivalpaSettings extends CRM_Core_Form {
      * @return array|NULL
      *   reference to the array of default values
      */
-    public function setDefaultValues()    {
+    public function setDefaultValues()
+    {
         $config = $this->config->get();
         $this->_defaults['debugMode'] = $config["debug-mode"];
         $this->_defaults['textLineWidth'] = $config["text-line-width"]["value"];

--- a/CRM/Civalpa/HeaderManipulator.php
+++ b/CRM/Civalpa/HeaderManipulator.php
@@ -2,7 +2,6 @@
 
 class CRM_Civalpa_HeaderManipulator
 {
-
     public static function update(&$params, array $config, string $debugMessage = "")
     {
         foreach ($config["headers"] as $headerConfig) {

--- a/CRM/Civalpa/HeaderManipulator.php
+++ b/CRM/Civalpa/HeaderManipulator.php
@@ -1,36 +1,38 @@
 <?php
 
-class CRM_Civalpa_HeaderManipulator {
+class CRM_Civalpa_HeaderManipulator
+{
 
-  public static function update(&$params, array $config, string $debugMessage = "") {
-    foreach ($config["headers"] as $headerConfig) {
-      $headerName = $headerConfig["name"];
-      if ($headerConfig["unset"]) {
-        if (isset($params[$headerName])) {
-          unset($params[$headerName]);
-          $debugMessage .= "headerUnset:".$headerName.",";
-        } else if (isset($params["headers"]) && isset($params["headers"][$headerName])) {
-          unset($params["headers"][$headerName]);
-          $debugMessage .= "headerUnset:".$headerName.",";
+    public static function update(&$params, array $config, string $debugMessage = "")
+    {
+        foreach ($config["headers"] as $headerConfig) {
+            $headerName = $headerConfig["name"];
+            if ($headerConfig["unset"]) {
+                if (isset($params[$headerName])) {
+                    unset($params[$headerName]);
+                    $debugMessage .= "headerUnset:".$headerName.",";
+                } elseif (isset($params["headers"]) && isset($params["headers"][$headerName])) {
+                    unset($params["headers"][$headerName]);
+                    $debugMessage .= "headerUnset:".$headerName.",";
+                }
+            } elseif ($headerConfig["set"]) {
+                if (isset($params[$headerName])) {
+                    $params[$headerName] = $headerConfig["value"];
+                    $debugMessage .= "headerSet:".$headerName.",";
+                } else {
+                    if (!isset($params["headers"])) {
+                        $params["headers"] = [];
+                    }
+                    $params["headers"][$headerName] = $headerConfig["value"];
+                    $debugMessage .= "headerSet:".$headerName.",";
+                }
+            }
         }
-      } else if ($headerConfig["set"]) {
-        if (isset($params[$headerName])) {
-          $params[$headerName] = $headerConfig["value"];
-          $debugMessage .= "headerSet:".$headerName.",";
-        } else {
-          if (!isset($params["headers"])) {
-            $params["headers"] = [];
-          }
-          $params["headers"][$headerName] = $headerConfig["value"];
-          $debugMessage .= "headerSet:".$headerName.",";
+        if ($config["debug-mode"]) {
+            if (!isset($params["headers"])) {
+                $params["headers"] = [];
+            }
+            $params["headers"]["X-CIVALPA-DEBUG"] = $debugMessage;
         }
-      }
     }
-    if ($config["debug-mode"]) {
-      if (!isset($params["headers"])) {
-        $params["headers"] = [];
-      }
-      $params["headers"]["X-CIVALPA-DEBUG"] = $debugMessage;
-    }
-  }
 }

--- a/CRM/Civalpa/TextFormatter.php
+++ b/CRM/Civalpa/TextFormatter.php
@@ -1,29 +1,31 @@
 <?php
 
-class CRM_Civalpa_TextFormatter {
+class CRM_Civalpa_TextFormatter
+{
 
-  public static function format(array $config, string $text = "", string $html = ""): array {
-    $response = [
-      "text" => $text,
-      "html" => $html,
-      "debug" => "",  
-    ];
-    // format the text if the format flag is set and the value is gt 0.
-    if ($config["text-line-width"]["use"] && $config["text-line-width"]["value"] > 0) {
-      $wrappedText = wordwrap($text, $config["text-line-width"]["value"]);
-      if ($wrappedText !== $text) {
-        $response["debug"] .= "textWrap,";
-        $response["text"] = $wrappedText;
-      }
+    public static function format(array $config, string $text = "", string $html = ""): array
+    {
+        $response = [
+        "text" => $text,
+        "html" => $html,
+        "debug" => "",
+        ];
+      // format the text if the format flag is set and the value is gt 0.
+        if ($config["text-line-width"]["use"] && $config["text-line-width"]["value"] > 0) {
+            $wrappedText = wordwrap($text, $config["text-line-width"]["value"]);
+            if ($wrappedText !== $text) {
+                $response["debug"] .= "textWrap,";
+                $response["text"] = $wrappedText;
+            }
+        }
+      // format the html if the format flag is set and the value is gt 0.
+        if ($config["html-line-width"]["use"] && $config["html-line-width"]["value"] > 0) {
+            $wrappedText = wordwrap($html, $config["html-line-width"]["value"]);
+            if ($wrappedText !== $html) {
+                $response["debug"] .= "htmlWrap,";
+                $response["html"] = $wrappedText;
+            }
+        }
+        return $response;
     }
-    // format the html if the format flag is set and the value is gt 0.
-    if ($config["html-line-width"]["use"] && $config["html-line-width"]["value"] > 0) {
-      $wrappedText = wordwrap($html, $config["html-line-width"]["value"]);
-      if ($wrappedText !== $html) {
-        $response["debug"] .= "htmlWrap,";
-        $response["html"] = $wrappedText;
-      }
-    }
-    return $response;
-  }
 }

--- a/CRM/Civalpa/TextFormatter.php
+++ b/CRM/Civalpa/TextFormatter.php
@@ -2,7 +2,6 @@
 
 class CRM_Civalpa_TextFormatter
 {
-
     public static function format(array $config, string $text = "", string $html = ""): array
     {
         $response = [
@@ -10,7 +9,7 @@ class CRM_Civalpa_TextFormatter
         "html" => $html,
         "debug" => "",
         ];
-      // format the text if the format flag is set and the value is gt 0.
+        // format the text if the format flag is set and the value is gt 0.
         if ($config["text-line-width"]["use"] && $config["text-line-width"]["value"] > 0) {
             $wrappedText = wordwrap($text, $config["text-line-width"]["value"]);
             if ($wrappedText !== $text) {
@@ -18,7 +17,7 @@ class CRM_Civalpa_TextFormatter
                 $response["text"] = $wrappedText;
             }
         }
-      // format the html if the format flag is set and the value is gt 0.
+        // format the html if the format flag is set and the value is gt 0.
         if ($config["html-line-width"]["use"] && $config["html-line-width"]["value"] > 0) {
             $wrappedText = wordwrap($html, $config["html-line-width"]["value"]);
             if ($wrappedText !== $html) {

--- a/CRM/Civalpa/Upgrader.php
+++ b/CRM/Civalpa/Upgrader.php
@@ -35,7 +35,7 @@ class CRM_Civalpa_Upgrader extends CRM_Civalpa_Upgrader_Base
         }
     }
 
-  // By convention, functions that look like "function upgrade_NNNN()" are
+    // By convention, functions that look like "function upgrade_NNNN()" are
   // upgrade tasks. They are executed in order (like Drupal's hook_update_N).
 
   /**

--- a/CRM/Civalpa/Upgrader.php
+++ b/CRM/Civalpa/Upgrader.php
@@ -4,14 +4,16 @@ use CRM_Civalpa_ExtensionUtil as E;
 /**
  * Collection of upgrade steps.
  */
-class CRM_Civalpa_Upgrader extends CRM_Civalpa_Upgrader_Base {
+class CRM_Civalpa_Upgrader extends CRM_Civalpa_Upgrader_Base
+{
 
     /**
      * Install process. Init database.
      *
      * @throws CRM_Core_Exception
      */
-    public function install() {
+    public function install()
+    {
         $config = new CRM_Civalpa_Config($this->extensionName);
         // Create default configs
         if (!$config->create()) {
@@ -24,7 +26,8 @@ class CRM_Civalpa_Upgrader extends CRM_Civalpa_Upgrader_Base {
      *
      * @throws CRM_Core_Exception
      */
-    public function uninstall() {
+    public function uninstall()
+    {
         $config = new CRM_Civalpa_Config($this->extensionName);
         // delete current configs
         if (!$config->remove()) {
@@ -143,5 +146,4 @@ class CRM_Civalpa_Upgrader extends CRM_Civalpa_Upgrader_Base {
   //   }
   //   return TRUE;
   // }
-
 }

--- a/CRM/Civalpa/Upgrader/Base.php
+++ b/CRM/Civalpa/Upgrader/Base.php
@@ -14,38 +14,38 @@ class CRM_Civalpa_Upgrader_Base
    */
     public static $instance;
 
-  /**
-   * @var CRM_Queue_TaskContext
-   */
+    /**
+     * @var CRM_Queue_TaskContext
+     */
     protected $ctx;
 
-  /**
-   * @var string
-   *   eg 'com.example.myextension'
-   */
+    /**
+     * @var string
+     *   eg 'com.example.myextension'
+     */
     protected $extensionName;
 
-  /**
-   * @var string
-   *   full path to the extension's source tree
-   */
+    /**
+     * @var string
+     *   full path to the extension's source tree
+     */
     protected $extensionDir;
 
-  /**
-   * @var array
-   *   sorted numerically
-   */
+    /**
+     * @var array
+     *   sorted numerically
+     */
     private $revisions;
 
-  /**
-   * @var bool
-   *   Flag to clean up extension revision data in civicrm_setting
-   */
+    /**
+     * @var bool
+     *   Flag to clean up extension revision data in civicrm_setting
+     */
     private $revisionStorageIsDeprecated = false;
 
-  /**
-   * Obtain a reference to the active upgrade handler.
-   */
+    /**
+     * Obtain a reference to the active upgrade handler.
+     */
     public static function instance()
     {
         if (!self::$instance) {
@@ -57,16 +57,16 @@ class CRM_Civalpa_Upgrader_Base
         return self::$instance;
     }
 
-  /**
-   * Adapter that lets you add normal (non-static) member functions to the queue.
-   *
-   * Note: Each upgrader instance should only be associated with one
-   * task-context; otherwise, this will be non-reentrant.
-   *
-   * ```
-   * CRM_Civalpa_Upgrader_Base::_queueAdapter($ctx, 'methodName', 'arg1', 'arg2');
-   * ```
-   */
+    /**
+     * Adapter that lets you add normal (non-static) member functions to the queue.
+     *
+     * Note: Each upgrader instance should only be associated with one
+     * task-context; otherwise, this will be non-reentrant.
+     *
+     * ```
+     * CRM_Civalpa_Upgrader_Base::_queueAdapter($ctx, 'methodName', 'arg1', 'arg2');
+     * ```
+     */
     public static function _queueAdapter()
     {
         $instance = self::instance();
@@ -77,41 +77,41 @@ class CRM_Civalpa_Upgrader_Base
         return call_user_func_array([$instance, $method], $args);
     }
 
-  /**
-   * CRM_Civalpa_Upgrader_Base constructor.
-   *
-   * @param $extensionName
-   * @param $extensionDir
-   */
+    /**
+     * CRM_Civalpa_Upgrader_Base constructor.
+     *
+     * @param $extensionName
+     * @param $extensionDir
+     */
     public function __construct($extensionName, $extensionDir)
     {
         $this->extensionName = $extensionName;
         $this->extensionDir = $extensionDir;
     }
 
-  // ******** Task helpers ********
+    // ******** Task helpers ********
 
-  /**
-   * Run a CustomData file.
-   *
-   * @param string $relativePath
-   *   the CustomData XML file path (relative to this extension's dir)
-   * @return bool
-   */
+    /**
+     * Run a CustomData file.
+     *
+     * @param string $relativePath
+     *   the CustomData XML file path (relative to this extension's dir)
+     * @return bool
+     */
     public function executeCustomDataFile($relativePath)
     {
         $xml_file = $this->extensionDir . '/' . $relativePath;
         return $this->executeCustomDataFileByAbsPath($xml_file);
     }
 
-  /**
-   * Run a CustomData file
-   *
-   * @param string $xml_file
-   *   the CustomData XML file path (absolute path)
-   *
-   * @return bool
-   */
+    /**
+     * Run a CustomData file
+     *
+     * @param string $xml_file
+     *   the CustomData XML file path (absolute path)
+     *
+     * @return bool
+     */
     protected function executeCustomDataFileByAbsPath($xml_file)
     {
         $import = new CRM_Utils_Migrate_Import();
@@ -119,14 +119,14 @@ class CRM_Civalpa_Upgrader_Base
         return true;
     }
 
-  /**
-   * Run a SQL file.
-   *
-   * @param string $relativePath
-   *   the SQL file path (relative to this extension's dir)
-   *
-   * @return bool
-   */
+    /**
+     * Run a SQL file.
+     *
+     * @param string $relativePath
+     *   the SQL file path (relative to this extension's dir)
+     *
+     * @return bool
+     */
     public function executeSqlFile($relativePath)
     {
         CRM_Utils_File::sourceSQLFile(
@@ -136,19 +136,19 @@ class CRM_Civalpa_Upgrader_Base
         return true;
     }
 
-  /**
-   * Run the sql commands in the specified file.
-   *
-   * @param string $tplFile
-   *   The SQL file path (relative to this extension's dir).
-   *   Ex: "sql/mydata.mysql.tpl".
-   *
-   * @return bool
-   * @throws \CRM_Core_Exception
-   */
+    /**
+     * Run the sql commands in the specified file.
+     *
+     * @param string $tplFile
+     *   The SQL file path (relative to this extension's dir).
+     *   Ex: "sql/mydata.mysql.tpl".
+     *
+     * @return bool
+     * @throws \CRM_Core_Exception
+     */
     public function executeSqlTemplate($tplFile)
     {
-      // Assign multilingual variable to Smarty.
+        // Assign multilingual variable to Smarty.
         $upgrade = new CRM_Upgrade_Form();
 
         $tplFile = CRM_Utils_File::isAbsolute($tplFile) ? $tplFile : $this->extensionDir . DIRECTORY_SEPARATOR . $tplFile;
@@ -163,31 +163,31 @@ class CRM_Civalpa_Upgrader_Base
         return true;
     }
 
-  /**
-   * Run one SQL query.
-   *
-   * This is just a wrapper for CRM_Core_DAO::executeSql, but it
-   * provides syntactic sugar for queueing several tasks that
-   * run different queries
-   *
-   * @return bool
-   */
+    /**
+     * Run one SQL query.
+     *
+     * This is just a wrapper for CRM_Core_DAO::executeSql, but it
+     * provides syntactic sugar for queueing several tasks that
+     * run different queries
+     *
+     * @return bool
+     */
     public function executeSql($query, $params = [])
     {
-      // FIXME verify that we raise an exception on error
+        // FIXME verify that we raise an exception on error
         CRM_Core_DAO::executeQuery($query, $params);
         return true;
     }
 
-  /**
-   * Syntactic sugar for enqueuing a task which calls a function in this class.
-   *
-   * The task is weighted so that it is processed
-   * as part of the currently-pending revision.
-   *
-   * After passing the $funcName, you can also pass parameters that will go to
-   * the function. Note that all params must be serializable.
-   */
+    /**
+     * Syntactic sugar for enqueuing a task which calls a function in this class.
+     *
+     * The task is weighted so that it is processed
+     * as part of the currently-pending revision.
+     *
+     * After passing the $funcName, you can also pass parameters that will go to
+     * the function. Note that all params must be serializable.
+     */
     public function addTask($title)
     {
         $args = func_get_args();
@@ -200,13 +200,13 @@ class CRM_Civalpa_Upgrader_Base
         return $this->queue->createItem($task, ['weight' => -1]);
     }
 
-  // ******** Revision-tracking helpers ********
+    // ******** Revision-tracking helpers ********
 
-  /**
-   * Determine if there are any pending revisions.
-   *
-   * @return bool
-   */
+    /**
+     * Determine if there are any pending revisions.
+     *
+     * @return bool
+     */
     public function hasPendingRevisions()
     {
         $revisions = $this->getRevisions();
@@ -222,11 +222,11 @@ class CRM_Civalpa_Upgrader_Base
         return ($currentRevision < max($revisions));
     }
 
-  /**
-   * Add any pending revisions to the queue.
-   *
-   * @param CRM_Queue_Queue $queue
-   */
+    /**
+     * Add any pending revisions to the queue.
+     *
+     * @param CRM_Queue_Queue $queue
+     */
     public function enqueuePendingRevisions(CRM_Queue_Queue $queue)
     {
         $this->queue = $queue;
@@ -258,12 +258,12 @@ class CRM_Civalpa_Upgrader_Base
         }
     }
 
-  /**
-   * Get a list of revisions.
-   *
-   * @return array
-   *   revisionNumbers sorted numerically
-   */
+    /**
+     * Get a list of revisions.
+     *
+     * @return array
+     *   revisionNumbers sorted numerically
+     */
     public function getRevisions()
     {
         if (!is_array($this->revisions)) {
@@ -303,7 +303,7 @@ class CRM_Civalpa_Upgrader_Base
     public function setCurrentRevision($revision)
     {
         CRM_Core_BAO_Extension::setSchemaVersion($this->extensionName, $revision);
-      // clean up legacy schema version store (CRM-19252)
+        // clean up legacy schema version store (CRM-19252)
         $this->deleteDeprecatedRevision();
         return true;
     }
@@ -318,11 +318,11 @@ class CRM_Civalpa_Upgrader_Base
         }
     }
 
-  // ******** Hook delegates ********
+    // ******** Hook delegates ********
 
-  /**
-   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
-   */
+    /**
+     * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+     */
     public function onInstall()
     {
         $files = glob($this->extensionDir . '/sql/*_install.sql');
@@ -348,9 +348,9 @@ class CRM_Civalpa_Upgrader_Base
         }
     }
 
-  /**
-   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
-   */
+    /**
+     * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
+     */
     public function onPostInstall()
     {
         $revisions = $this->getRevisions();
@@ -362,9 +362,9 @@ class CRM_Civalpa_Upgrader_Base
         }
     }
 
-  /**
-   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
-   */
+    /**
+     * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
+     */
     public function onUninstall()
     {
         $files = glob($this->extensionDir . '/sql/*_uninstall.mysql.tpl');
@@ -384,23 +384,23 @@ class CRM_Civalpa_Upgrader_Base
         }
     }
 
-  /**
-   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
-   */
+    /**
+     * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+     */
     public function onEnable()
     {
-      // stub for possible future use
+        // stub for possible future use
         if (is_callable([$this, 'enable'])) {
             $this->enable();
         }
     }
 
-  /**
-   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
-   */
+    /**
+     * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
+     */
     public function onDisable()
     {
-      // stub for possible future use
+        // stub for possible future use
         if (is_callable([$this, 'disable'])) {
             $this->disable();
         }

--- a/CRM/Civalpa/Upgrader/Base.php
+++ b/CRM/Civalpa/Upgrader/Base.php
@@ -6,54 +6,56 @@ use CRM_Civalpa_ExtensionUtil as E;
 /**
  * Base class which provides helpers to execute upgrade logic
  */
-class CRM_Civalpa_Upgrader_Base {
+class CRM_Civalpa_Upgrader_Base
+{
 
   /**
    * @var CRM_Civalpa_Upgrader_Base
    */
-  public static $instance;
+    public static $instance;
 
   /**
    * @var CRM_Queue_TaskContext
    */
-  protected $ctx;
+    protected $ctx;
 
   /**
    * @var string
    *   eg 'com.example.myextension'
    */
-  protected $extensionName;
+    protected $extensionName;
 
   /**
    * @var string
    *   full path to the extension's source tree
    */
-  protected $extensionDir;
+    protected $extensionDir;
 
   /**
    * @var array
    *   sorted numerically
    */
-  private $revisions;
+    private $revisions;
 
   /**
    * @var bool
    *   Flag to clean up extension revision data in civicrm_setting
    */
-  private $revisionStorageIsDeprecated = FALSE;
+    private $revisionStorageIsDeprecated = false;
 
   /**
    * Obtain a reference to the active upgrade handler.
    */
-  public static function instance() {
-    if (!self::$instance) {
-      self::$instance = new CRM_Civalpa_Upgrader(
-        'civalpa',
-        E::path()
-      );
+    public static function instance()
+    {
+        if (!self::$instance) {
+            self::$instance = new CRM_Civalpa_Upgrader(
+                'civalpa',
+                E::path()
+            );
+        }
+        return self::$instance;
     }
-    return self::$instance;
-  }
 
   /**
    * Adapter that lets you add normal (non-static) member functions to the queue.
@@ -65,14 +67,15 @@ class CRM_Civalpa_Upgrader_Base {
    * CRM_Civalpa_Upgrader_Base::_queueAdapter($ctx, 'methodName', 'arg1', 'arg2');
    * ```
    */
-  public static function _queueAdapter() {
-    $instance = self::instance();
-    $args = func_get_args();
-    $instance->ctx = array_shift($args);
-    $instance->queue = $instance->ctx->queue;
-    $method = array_shift($args);
-    return call_user_func_array([$instance, $method], $args);
-  }
+    public static function _queueAdapter()
+    {
+        $instance = self::instance();
+        $args = func_get_args();
+        $instance->ctx = array_shift($args);
+        $instance->queue = $instance->ctx->queue;
+        $method = array_shift($args);
+        return call_user_func_array([$instance, $method], $args);
+    }
 
   /**
    * CRM_Civalpa_Upgrader_Base constructor.
@@ -80,10 +83,11 @@ class CRM_Civalpa_Upgrader_Base {
    * @param $extensionName
    * @param $extensionDir
    */
-  public function __construct($extensionName, $extensionDir) {
-    $this->extensionName = $extensionName;
-    $this->extensionDir = $extensionDir;
-  }
+    public function __construct($extensionName, $extensionDir)
+    {
+        $this->extensionName = $extensionName;
+        $this->extensionDir = $extensionDir;
+    }
 
   // ******** Task helpers ********
 
@@ -94,10 +98,11 @@ class CRM_Civalpa_Upgrader_Base {
    *   the CustomData XML file path (relative to this extension's dir)
    * @return bool
    */
-  public function executeCustomDataFile($relativePath) {
-    $xml_file = $this->extensionDir . '/' . $relativePath;
-    return $this->executeCustomDataFileByAbsPath($xml_file);
-  }
+    public function executeCustomDataFile($relativePath)
+    {
+        $xml_file = $this->extensionDir . '/' . $relativePath;
+        return $this->executeCustomDataFileByAbsPath($xml_file);
+    }
 
   /**
    * Run a CustomData file
@@ -107,11 +112,12 @@ class CRM_Civalpa_Upgrader_Base {
    *
    * @return bool
    */
-  protected function executeCustomDataFileByAbsPath($xml_file) {
-    $import = new CRM_Utils_Migrate_Import();
-    $import->run($xml_file);
-    return TRUE;
-  }
+    protected function executeCustomDataFileByAbsPath($xml_file)
+    {
+        $import = new CRM_Utils_Migrate_Import();
+        $import->run($xml_file);
+        return true;
+    }
 
   /**
    * Run a SQL file.
@@ -121,13 +127,14 @@ class CRM_Civalpa_Upgrader_Base {
    *
    * @return bool
    */
-  public function executeSqlFile($relativePath) {
-    CRM_Utils_File::sourceSQLFile(
-      CIVICRM_DSN,
-      $this->extensionDir . DIRECTORY_SEPARATOR . $relativePath
-    );
-    return TRUE;
-  }
+    public function executeSqlFile($relativePath)
+    {
+        CRM_Utils_File::sourceSQLFile(
+            CIVICRM_DSN,
+            $this->extensionDir . DIRECTORY_SEPARATOR . $relativePath
+        );
+        return true;
+    }
 
   /**
    * Run the sql commands in the specified file.
@@ -139,18 +146,22 @@ class CRM_Civalpa_Upgrader_Base {
    * @return bool
    * @throws \CRM_Core_Exception
    */
-  public function executeSqlTemplate($tplFile) {
-    // Assign multilingual variable to Smarty.
-    $upgrade = new CRM_Upgrade_Form();
+    public function executeSqlTemplate($tplFile)
+    {
+      // Assign multilingual variable to Smarty.
+        $upgrade = new CRM_Upgrade_Form();
 
-    $tplFile = CRM_Utils_File::isAbsolute($tplFile) ? $tplFile : $this->extensionDir . DIRECTORY_SEPARATOR . $tplFile;
-    $smarty = CRM_Core_Smarty::singleton();
-    $smarty->assign('domainID', CRM_Core_Config::domainID());
-    CRM_Utils_File::sourceSQLFile(
-      CIVICRM_DSN, $smarty->fetch($tplFile), NULL, TRUE
-    );
-    return TRUE;
-  }
+        $tplFile = CRM_Utils_File::isAbsolute($tplFile) ? $tplFile : $this->extensionDir . DIRECTORY_SEPARATOR . $tplFile;
+        $smarty = CRM_Core_Smarty::singleton();
+        $smarty->assign('domainID', CRM_Core_Config::domainID());
+        CRM_Utils_File::sourceSQLFile(
+            CIVICRM_DSN,
+            $smarty->fetch($tplFile),
+            null,
+            true
+        );
+        return true;
+    }
 
   /**
    * Run one SQL query.
@@ -161,11 +172,12 @@ class CRM_Civalpa_Upgrader_Base {
    *
    * @return bool
    */
-  public function executeSql($query, $params = []) {
-    // FIXME verify that we raise an exception on error
-    CRM_Core_DAO::executeQuery($query, $params);
-    return TRUE;
-  }
+    public function executeSql($query, $params = [])
+    {
+      // FIXME verify that we raise an exception on error
+        CRM_Core_DAO::executeQuery($query, $params);
+        return true;
+    }
 
   /**
    * Syntactic sugar for enqueuing a task which calls a function in this class.
@@ -176,16 +188,17 @@ class CRM_Civalpa_Upgrader_Base {
    * After passing the $funcName, you can also pass parameters that will go to
    * the function. Note that all params must be serializable.
    */
-  public function addTask($title) {
-    $args = func_get_args();
-    $title = array_shift($args);
-    $task = new CRM_Queue_Task(
-      [get_class($this), '_queueAdapter'],
-      $args,
-      $title
-    );
-    return $this->queue->createItem($task, ['weight' => -1]);
-  }
+    public function addTask($title)
+    {
+        $args = func_get_args();
+        $title = array_shift($args);
+        $task = new CRM_Queue_Task(
+            [get_class($this), '_queueAdapter'],
+            $args,
+            $title
+        );
+        return $this->queue->createItem($task, ['weight' => -1]);
+    }
 
   // ******** Revision-tracking helpers ********
 
@@ -194,54 +207,56 @@ class CRM_Civalpa_Upgrader_Base {
    *
    * @return bool
    */
-  public function hasPendingRevisions() {
-    $revisions = $this->getRevisions();
-    $currentRevision = $this->getCurrentRevision();
+    public function hasPendingRevisions()
+    {
+        $revisions = $this->getRevisions();
+        $currentRevision = $this->getCurrentRevision();
 
-    if (empty($revisions)) {
-      return FALSE;
-    }
-    if (empty($currentRevision)) {
-      return TRUE;
-    }
+        if (empty($revisions)) {
+            return false;
+        }
+        if (empty($currentRevision)) {
+            return true;
+        }
 
-    return ($currentRevision < max($revisions));
-  }
+        return ($currentRevision < max($revisions));
+    }
 
   /**
    * Add any pending revisions to the queue.
    *
    * @param CRM_Queue_Queue $queue
    */
-  public function enqueuePendingRevisions(CRM_Queue_Queue $queue) {
-    $this->queue = $queue;
+    public function enqueuePendingRevisions(CRM_Queue_Queue $queue)
+    {
+        $this->queue = $queue;
 
-    $currentRevision = $this->getCurrentRevision();
-    foreach ($this->getRevisions() as $revision) {
-      if ($revision > $currentRevision) {
-        $title = E::ts('Upgrade %1 to revision %2', [
-          1 => $this->extensionName,
-          2 => $revision,
-        ]);
+        $currentRevision = $this->getCurrentRevision();
+        foreach ($this->getRevisions() as $revision) {
+            if ($revision > $currentRevision) {
+                $title = E::ts('Upgrade %1 to revision %2', [
+                1 => $this->extensionName,
+                2 => $revision,
+                ]);
 
-        // note: don't use addTask() because it sets weight=-1
+                // note: don't use addTask() because it sets weight=-1
 
-        $task = new CRM_Queue_Task(
-          [get_class($this), '_queueAdapter'],
-          ['upgrade_' . $revision],
-          $title
-        );
-        $this->queue->createItem($task);
+                $task = new CRM_Queue_Task(
+                    [get_class($this), '_queueAdapter'],
+                    ['upgrade_' . $revision],
+                    $title
+                );
+                $this->queue->createItem($task);
 
-        $task = new CRM_Queue_Task(
-          [get_class($this), '_queueAdapter'],
-          ['setCurrentRevision', $revision],
-          $title
-        );
-        $this->queue->createItem($task);
-      }
+                $task = new CRM_Queue_Task(
+                    [get_class($this), '_queueAdapter'],
+                    ['setCurrentRevision', $revision],
+                    $title
+                );
+                $this->queue->createItem($task);
+            }
+        }
     }
-  }
 
   /**
    * Get a list of revisions.
@@ -249,148 +264,158 @@ class CRM_Civalpa_Upgrader_Base {
    * @return array
    *   revisionNumbers sorted numerically
    */
-  public function getRevisions() {
-    if (!is_array($this->revisions)) {
-      $this->revisions = [];
+    public function getRevisions()
+    {
+        if (!is_array($this->revisions)) {
+            $this->revisions = [];
 
-      $clazz = new ReflectionClass(get_class($this));
-      $methods = $clazz->getMethods();
-      foreach ($methods as $method) {
-        if (preg_match('/^upgrade_(.*)/', $method->name, $matches)) {
-          $this->revisions[] = $matches[1];
+            $clazz = new ReflectionClass(get_class($this));
+            $methods = $clazz->getMethods();
+            foreach ($methods as $method) {
+                if (preg_match('/^upgrade_(.*)/', $method->name, $matches)) {
+                    $this->revisions[] = $matches[1];
+                }
+            }
+            sort($this->revisions, SORT_NUMERIC);
         }
-      }
-      sort($this->revisions, SORT_NUMERIC);
+
+        return $this->revisions;
     }
 
-    return $this->revisions;
-  }
-
-  public function getCurrentRevision() {
-    $revision = CRM_Core_BAO_Extension::getSchemaVersion($this->extensionName);
-    if (!$revision) {
-      $revision = $this->getCurrentRevisionDeprecated();
+    public function getCurrentRevision()
+    {
+        $revision = CRM_Core_BAO_Extension::getSchemaVersion($this->extensionName);
+        if (!$revision) {
+            $revision = $this->getCurrentRevisionDeprecated();
+        }
+        return $revision;
     }
-    return $revision;
-  }
 
-  private function getCurrentRevisionDeprecated() {
-    $key = $this->extensionName . ':version';
-    if ($revision = \Civi::settings()->get($key)) {
-      $this->revisionStorageIsDeprecated = TRUE;
+    private function getCurrentRevisionDeprecated()
+    {
+        $key = $this->extensionName . ':version';
+        if ($revision = \Civi::settings()->get($key)) {
+            $this->revisionStorageIsDeprecated = true;
+        }
+        return $revision;
     }
-    return $revision;
-  }
 
-  public function setCurrentRevision($revision) {
-    CRM_Core_BAO_Extension::setSchemaVersion($this->extensionName, $revision);
-    // clean up legacy schema version store (CRM-19252)
-    $this->deleteDeprecatedRevision();
-    return TRUE;
-  }
-
-  private function deleteDeprecatedRevision() {
-    if ($this->revisionStorageIsDeprecated) {
-      $setting = new CRM_Core_BAO_Setting();
-      $setting->name = $this->extensionName . ':version';
-      $setting->delete();
-      CRM_Core_Error::debug_log_message("Migrated extension schema revision ID for {$this->extensionName} from civicrm_setting (deprecated) to civicrm_extension.\n");
+    public function setCurrentRevision($revision)
+    {
+        CRM_Core_BAO_Extension::setSchemaVersion($this->extensionName, $revision);
+      // clean up legacy schema version store (CRM-19252)
+        $this->deleteDeprecatedRevision();
+        return true;
     }
-  }
+
+    private function deleteDeprecatedRevision()
+    {
+        if ($this->revisionStorageIsDeprecated) {
+            $setting = new CRM_Core_BAO_Setting();
+            $setting->name = $this->extensionName . ':version';
+            $setting->delete();
+            CRM_Core_Error::debug_log_message("Migrated extension schema revision ID for {$this->extensionName} from civicrm_setting (deprecated) to civicrm_extension.\n");
+        }
+    }
 
   // ******** Hook delegates ********
 
   /**
    * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
    */
-  public function onInstall() {
-    $files = glob($this->extensionDir . '/sql/*_install.sql');
-    if (is_array($files)) {
-      foreach ($files as $file) {
-        CRM_Utils_File::sourceSQLFile(CIVICRM_DSN, $file);
-      }
+    public function onInstall()
+    {
+        $files = glob($this->extensionDir . '/sql/*_install.sql');
+        if (is_array($files)) {
+            foreach ($files as $file) {
+                CRM_Utils_File::sourceSQLFile(CIVICRM_DSN, $file);
+            }
+        }
+        $files = glob($this->extensionDir . '/sql/*_install.mysql.tpl');
+        if (is_array($files)) {
+            foreach ($files as $file) {
+                $this->executeSqlTemplate($file);
+            }
+        }
+        $files = glob($this->extensionDir . '/xml/*_install.xml');
+        if (is_array($files)) {
+            foreach ($files as $file) {
+                $this->executeCustomDataFileByAbsPath($file);
+            }
+        }
+        if (is_callable([$this, 'install'])) {
+            $this->install();
+        }
     }
-    $files = glob($this->extensionDir . '/sql/*_install.mysql.tpl');
-    if (is_array($files)) {
-      foreach ($files as $file) {
-        $this->executeSqlTemplate($file);
-      }
-    }
-    $files = glob($this->extensionDir . '/xml/*_install.xml');
-    if (is_array($files)) {
-      foreach ($files as $file) {
-        $this->executeCustomDataFileByAbsPath($file);
-      }
-    }
-    if (is_callable([$this, 'install'])) {
-      $this->install();
-    }
-  }
 
   /**
    * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
    */
-  public function onPostInstall() {
-    $revisions = $this->getRevisions();
-    if (!empty($revisions)) {
-      $this->setCurrentRevision(max($revisions));
+    public function onPostInstall()
+    {
+        $revisions = $this->getRevisions();
+        if (!empty($revisions)) {
+            $this->setCurrentRevision(max($revisions));
+        }
+        if (is_callable([$this, 'postInstall'])) {
+            $this->postInstall();
+        }
     }
-    if (is_callable([$this, 'postInstall'])) {
-      $this->postInstall();
-    }
-  }
 
   /**
    * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
    */
-  public function onUninstall() {
-    $files = glob($this->extensionDir . '/sql/*_uninstall.mysql.tpl');
-    if (is_array($files)) {
-      foreach ($files as $file) {
-        $this->executeSqlTemplate($file);
-      }
+    public function onUninstall()
+    {
+        $files = glob($this->extensionDir . '/sql/*_uninstall.mysql.tpl');
+        if (is_array($files)) {
+            foreach ($files as $file) {
+                $this->executeSqlTemplate($file);
+            }
+        }
+        if (is_callable([$this, 'uninstall'])) {
+            $this->uninstall();
+        }
+        $files = glob($this->extensionDir . '/sql/*_uninstall.sql');
+        if (is_array($files)) {
+            foreach ($files as $file) {
+                CRM_Utils_File::sourceSQLFile(CIVICRM_DSN, $file);
+            }
+        }
     }
-    if (is_callable([$this, 'uninstall'])) {
-      $this->uninstall();
-    }
-    $files = glob($this->extensionDir . '/sql/*_uninstall.sql');
-    if (is_array($files)) {
-      foreach ($files as $file) {
-        CRM_Utils_File::sourceSQLFile(CIVICRM_DSN, $file);
-      }
-    }
-  }
 
   /**
    * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
    */
-  public function onEnable() {
-    // stub for possible future use
-    if (is_callable([$this, 'enable'])) {
-      $this->enable();
+    public function onEnable()
+    {
+      // stub for possible future use
+        if (is_callable([$this, 'enable'])) {
+            $this->enable();
+        }
     }
-  }
 
   /**
    * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
    */
-  public function onDisable() {
-    // stub for possible future use
-    if (is_callable([$this, 'disable'])) {
-      $this->disable();
+    public function onDisable()
+    {
+      // stub for possible future use
+        if (is_callable([$this, 'disable'])) {
+            $this->disable();
+        }
     }
-  }
 
-  public function onUpgrade($op, CRM_Queue_Queue $queue = NULL) {
-    switch ($op) {
-      case 'check':
-        return [$this->hasPendingRevisions()];
+    public function onUpgrade($op, CRM_Queue_Queue $queue = null)
+    {
+        switch ($op) {
+            case 'check':
+                return [$this->hasPendingRevisions()];
 
-      case 'enqueue':
-        return $this->enqueuePendingRevisions($queue);
+            case 'enqueue':
+                return $this->enqueuePendingRevisions($queue);
 
-      default:
+            default:
+        }
     }
-  }
-
 }

--- a/civalpa.civix.php
+++ b/civalpa.civix.php
@@ -6,10 +6,11 @@
  * The ExtensionUtil class provides small stubs for accessing resources of this
  * extension.
  */
-class CRM_Civalpa_ExtensionUtil {
-  const SHORT_NAME = 'civalpa';
-  const LONG_NAME = 'civalpa';
-  const CLASS_PREFIX = 'CRM_Civalpa';
+class CRM_Civalpa_ExtensionUtil
+{
+    const SHORT_NAME = 'civalpa';
+    const LONG_NAME = 'civalpa';
+    const CLASS_PREFIX = 'CRM_Civalpa';
 
   /**
    * Translate a string using the extension's domain.
@@ -24,12 +25,13 @@ class CRM_Civalpa_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = []) {
-    if (!array_key_exists('domain', $params)) {
-      $params['domain'] = [self::LONG_NAME, NULL];
+    public static function ts($text, $params = [])
+    {
+        if (!array_key_exists('domain', $params)) {
+            $params['domain'] = [self::LONG_NAME, null];
+        }
+        return ts($text, $params);
     }
-    return ts($text, $params);
-  }
 
   /**
    * Get the URL of a resource file (in this extension).
@@ -41,12 +43,13 @@ class CRM_Civalpa_ExtensionUtil {
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
-  public static function url($file = NULL) {
-    if ($file === NULL) {
-      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    public static function url($file = null)
+    {
+        if ($file === null) {
+            return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+        }
+        return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
     }
-    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
-  }
 
   /**
    * Get the path of a resource file (in this extension).
@@ -58,10 +61,11 @@ class CRM_Civalpa_ExtensionUtil {
    *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
    *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
-  public static function path($file = NULL) {
-    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
-    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
-  }
+    public static function path($file = null)
+    {
+      // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+        return __DIR__ . ($file === null ? '' : (DIRECTORY_SEPARATOR . $file));
+    }
 
   /**
    * Get the name of a class within this extension.
@@ -71,10 +75,10 @@ class CRM_Civalpa_ExtensionUtil {
    * @return string
    *   Ex: 'CRM_Foo_Page_HelloWorld'.
    */
-  public static function findClass($suffix) {
-    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
-  }
-
+    public static function findClass($suffix)
+    {
+        return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+    }
 }
 
 use CRM_Civalpa_ExtensionUtil as E;
@@ -84,27 +88,27 @@ use CRM_Civalpa_ExtensionUtil as E;
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
-function _civalpa_civix_civicrm_config(&$config = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
+function _civalpa_civix_civicrm_config(&$config = null)
+{
+    static $configured = false;
+    if ($configured) {
+        return;
+    }
+    $configured = true;
 
-  $template =& CRM_Core_Smarty::singleton();
+    $template =& CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
-  $extDir = $extRoot . 'templates';
+    $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+    $extDir = $extRoot . 'templates';
 
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
+    if (is_array($template->template_dir)) {
+        array_unshift($template->template_dir, $extDir);
+    } else {
+        $template->template_dir = [$extDir, $template->template_dir];
+    }
 
-  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
-  set_include_path($include_path);
+    $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+    set_include_path($include_path);
 }
 
 /**
@@ -114,10 +118,11 @@ function _civalpa_civix_civicrm_config(&$config = NULL) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
  */
-function _civalpa_civix_civicrm_xmlMenu(&$files) {
-  foreach (_civalpa_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
-    $files[] = $file;
-  }
+function _civalpa_civix_civicrm_xmlMenu(&$files)
+{
+    foreach (_civalpa_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
+        $files[] = $file;
+    }
 }
 
 /**
@@ -125,11 +130,12 @@ function _civalpa_civix_civicrm_xmlMenu(&$files) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
-function _civalpa_civix_civicrm_install() {
-  _civalpa_civix_civicrm_config();
-  if ($upgrader = _civalpa_civix_upgrader()) {
-    $upgrader->onInstall();
-  }
+function _civalpa_civix_civicrm_install()
+{
+    _civalpa_civix_civicrm_config();
+    if ($upgrader = _civalpa_civix_upgrader()) {
+        $upgrader->onInstall();
+    }
 }
 
 /**
@@ -137,13 +143,14 @@ function _civalpa_civix_civicrm_install() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
-function _civalpa_civix_civicrm_postInstall() {
-  _civalpa_civix_civicrm_config();
-  if ($upgrader = _civalpa_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onPostInstall'])) {
-      $upgrader->onPostInstall();
+function _civalpa_civix_civicrm_postInstall()
+{
+    _civalpa_civix_civicrm_config();
+    if ($upgrader = _civalpa_civix_upgrader()) {
+        if (is_callable([$upgrader, 'onPostInstall'])) {
+            $upgrader->onPostInstall();
+        }
     }
-  }
 }
 
 /**
@@ -151,11 +158,12 @@ function _civalpa_civix_civicrm_postInstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
-function _civalpa_civix_civicrm_uninstall() {
-  _civalpa_civix_civicrm_config();
-  if ($upgrader = _civalpa_civix_upgrader()) {
-    $upgrader->onUninstall();
-  }
+function _civalpa_civix_civicrm_uninstall()
+{
+    _civalpa_civix_civicrm_config();
+    if ($upgrader = _civalpa_civix_upgrader()) {
+        $upgrader->onUninstall();
+    }
 }
 
 /**
@@ -163,13 +171,14 @@ function _civalpa_civix_civicrm_uninstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
-function _civalpa_civix_civicrm_enable() {
-  _civalpa_civix_civicrm_config();
-  if ($upgrader = _civalpa_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onEnable'])) {
-      $upgrader->onEnable();
+function _civalpa_civix_civicrm_enable()
+{
+    _civalpa_civix_civicrm_config();
+    if ($upgrader = _civalpa_civix_upgrader()) {
+        if (is_callable([$upgrader, 'onEnable'])) {
+            $upgrader->onEnable();
+        }
     }
-  }
 }
 
 /**
@@ -178,13 +187,14 @@ function _civalpa_civix_civicrm_enable() {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
  * @return mixed
  */
-function _civalpa_civix_civicrm_disable() {
-  _civalpa_civix_civicrm_config();
-  if ($upgrader = _civalpa_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onDisable'])) {
-      $upgrader->onDisable();
+function _civalpa_civix_civicrm_disable()
+{
+    _civalpa_civix_civicrm_config();
+    if ($upgrader = _civalpa_civix_upgrader()) {
+        if (is_callable([$upgrader, 'onDisable'])) {
+            $upgrader->onDisable();
+        }
     }
-  }
 }
 
 /**
@@ -199,22 +209,23 @@ function _civalpa_civix_civicrm_disable() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
-function _civalpa_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  if ($upgrader = _civalpa_civix_upgrader()) {
-    return $upgrader->onUpgrade($op, $queue);
-  }
+function _civalpa_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = null)
+{
+    if ($upgrader = _civalpa_civix_upgrader()) {
+        return $upgrader->onUpgrade($op, $queue);
+    }
 }
 
 /**
  * @return CRM_Civalpa_Upgrader
  */
-function _civalpa_civix_upgrader() {
-  if (!file_exists(__DIR__ . '/CRM/Civalpa/Upgrader.php')) {
-    return NULL;
-  }
-  else {
-    return CRM_Civalpa_Upgrader_Base::instance();
-  }
+function _civalpa_civix_upgrader()
+{
+    if (!file_exists(__DIR__ . '/CRM/Civalpa/Upgrader.php')) {
+        return null;
+    } else {
+        return CRM_Civalpa_Upgrader_Base::instance();
+    }
 }
 
 /**
@@ -228,33 +239,33 @@ function _civalpa_civix_upgrader() {
  *
  * @return array
  */
-function _civalpa_civix_find_files($dir, $pattern) {
-  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
+function _civalpa_civix_find_files($dir, $pattern)
+{
+    if (is_callable(['CRM_Utils_File', 'findFiles'])) {
+        return CRM_Utils_File::findFiles($dir, $pattern);
+    }
 
-  $todos = [$dir];
-  $result = [];
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_civalpa_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry[0] == '.') {
+    $todos = [$dir];
+    $result = [];
+    while (!empty($todos)) {
+        $subdir = array_shift($todos);
+        foreach (_civalpa_civix_glob("$subdir/$pattern") as $match) {
+            if (!is_dir($match)) {
+                $result[] = $match;
+            }
         }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
+        if ($dh = opendir($subdir)) {
+            while (false !== ($entry = readdir($dh))) {
+                $path = $subdir . DIRECTORY_SEPARATOR . $entry;
+                if ($entry[0] == '.') {
+                } elseif (is_dir($path)) {
+                    $todos[] = $path;
+                }
+            }
+            closedir($dh);
         }
-      }
-      closedir($dh);
     }
-  }
-  return $result;
+    return $result;
 }
 
 /**
@@ -264,21 +275,22 @@ function _civalpa_civix_find_files($dir, $pattern) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
  */
-function _civalpa_civix_civicrm_managed(&$entities) {
-  $mgdFiles = _civalpa_civix_find_files(__DIR__, '*.mgd.php');
-  sort($mgdFiles);
-  foreach ($mgdFiles as $file) {
-    $es = include $file;
-    foreach ($es as $e) {
-      if (empty($e['module'])) {
-        $e['module'] = E::LONG_NAME;
-      }
-      if (empty($e['params']['version'])) {
-        $e['params']['version'] = '3';
-      }
-      $entities[] = $e;
+function _civalpa_civix_civicrm_managed(&$entities)
+{
+    $mgdFiles = _civalpa_civix_find_files(__DIR__, '*.mgd.php');
+    sort($mgdFiles);
+    foreach ($mgdFiles as $file) {
+        $es = include $file;
+        foreach ($es as $e) {
+            if (empty($e['module'])) {
+                $e['module'] = E::LONG_NAME;
+            }
+            if (empty($e['params']['version'])) {
+                $e['params']['version'] = '3';
+            }
+            $entities[] = $e;
+        }
     }
-  }
 }
 
 /**
@@ -290,23 +302,24 @@ function _civalpa_civix_civicrm_managed(&$entities) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
-function _civalpa_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
-    return;
-  }
-
-  foreach (_civalpa_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
-    $name = preg_replace('/\.xml$/', '', basename($file));
-    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
-      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      throw new CRM_Core_Exception($errorMessage);
+function _civalpa_civix_civicrm_caseTypes(&$caseTypes)
+{
+    if (!is_dir(__DIR__ . '/xml/case')) {
+        return;
     }
-    $caseTypes[$name] = [
-      'module' => E::LONG_NAME,
-      'name' => $name,
-      'file' => $file,
-    ];
-  }
+
+    foreach (_civalpa_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
+        $name = preg_replace('/\.xml$/', '', basename($file));
+        if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
+            $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
+            throw new CRM_Core_Exception($errorMessage);
+        }
+        $caseTypes[$name] = [
+        'module' => E::LONG_NAME,
+        'name' => $name,
+        'file' => $file,
+        ];
+    }
 }
 
 /**
@@ -318,20 +331,21 @@ function _civalpa_civix_civicrm_caseTypes(&$caseTypes) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
-function _civalpa_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
-    return;
-  }
-
-  $files = _civalpa_civix_glob(__DIR__ . '/ang/*.ang.php');
-  foreach ($files as $file) {
-    $name = preg_replace(':\.ang\.php$:', '', basename($file));
-    $module = include $file;
-    if (empty($module['ext'])) {
-      $module['ext'] = E::LONG_NAME;
+function _civalpa_civix_civicrm_angularModules(&$angularModules)
+{
+    if (!is_dir(__DIR__ . '/ang')) {
+        return;
     }
-    $angularModules[$name] = $module;
-  }
+
+    $files = _civalpa_civix_glob(__DIR__ . '/ang/*.ang.php');
+    foreach ($files as $file) {
+        $name = preg_replace(':\.ang\.php$:', '', basename($file));
+        $module = include $file;
+        if (empty($module['ext'])) {
+            $module['ext'] = E::LONG_NAME;
+        }
+        $angularModules[$name] = $module;
+    }
 }
 
 /**
@@ -339,18 +353,19 @@ function _civalpa_civix_civicrm_angularModules(&$angularModules) {
  *
  * Find any and return any files matching "*.theme.php"
  */
-function _civalpa_civix_civicrm_themes(&$themes) {
-  $files = _civalpa_civix_glob(__DIR__ . '/*.theme.php');
-  foreach ($files as $file) {
-    $themeMeta = include $file;
-    if (empty($themeMeta['name'])) {
-      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+function _civalpa_civix_civicrm_themes(&$themes)
+{
+    $files = _civalpa_civix_glob(__DIR__ . '/*.theme.php');
+    foreach ($files as $file) {
+        $themeMeta = include $file;
+        if (empty($themeMeta['name'])) {
+            $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+        }
+        if (empty($themeMeta['ext'])) {
+            $themeMeta['ext'] = E::LONG_NAME;
+        }
+        $themes[$themeMeta['name']] = $themeMeta;
     }
-    if (empty($themeMeta['ext'])) {
-      $themeMeta['ext'] = E::LONG_NAME;
-    }
-    $themes[$themeMeta['name']] = $themeMeta;
-  }
 }
 
 /**
@@ -366,9 +381,10 @@ function _civalpa_civix_civicrm_themes(&$themes) {
  *
  * @return array
  */
-function _civalpa_civix_glob($pattern) {
-  $result = glob($pattern);
-  return is_array($result) ? $result : [];
+function _civalpa_civix_glob($pattern)
+{
+    $result = glob($pattern);
+    return is_array($result) ? $result : [];
 }
 
 /**
@@ -382,75 +398,78 @@ function _civalpa_civix_glob($pattern) {
  *
  * @return bool
  */
-function _civalpa_civix_insert_navigation_menu(&$menu, $path, $item) {
+function _civalpa_civix_insert_navigation_menu(&$menu, $path, $item)
+{
   // If we are done going down the path, insert menu
-  if (empty($path)) {
-    $menu[] = [
-      'attributes' => array_merge([
+    if (empty($path)) {
+        $menu[] = [
+        'attributes' => array_merge([
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-      ], $item),
-    ];
-    return TRUE;
-  }
-  else {
-    // Find an recurse into the next level down
-    $found = FALSE;
-    $path = explode('/', $path);
-    $first = array_shift($path);
-    foreach ($menu as $key => &$entry) {
-      if ($entry['attributes']['name'] == $first) {
-        if (!isset($entry['child'])) {
-          $entry['child'] = [];
+        ], $item),
+        ];
+        return true;
+    } else {
+      // Find an recurse into the next level down
+        $found = false;
+        $path = explode('/', $path);
+        $first = array_shift($path);
+        foreach ($menu as $key => &$entry) {
+            if ($entry['attributes']['name'] == $first) {
+                if (!isset($entry['child'])) {
+                    $entry['child'] = [];
+                }
+                $found = _civalpa_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+            }
         }
-        $found = _civalpa_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
-      }
+        return $found;
     }
-    return $found;
-  }
 }
 
 /**
  * (Delegated) Implements hook_civicrm_navigationMenu().
  */
-function _civalpa_civix_navigationMenu(&$nodes) {
-  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
-    _civalpa_civix_fixNavigationMenu($nodes);
-  }
+function _civalpa_civix_navigationMenu(&$nodes)
+{
+    if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+        _civalpa_civix_fixNavigationMenu($nodes);
+    }
 }
 
 /**
  * Given a navigation menu, generate navIDs for any items which are
  * missing them.
  */
-function _civalpa_civix_fixNavigationMenu(&$nodes) {
-  $maxNavID = 1;
-  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
-    if ($key === 'navID') {
-      $maxNavID = max($maxNavID, $item);
-    }
-  });
-  _civalpa_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+function _civalpa_civix_fixNavigationMenu(&$nodes)
+{
+    $maxNavID = 1;
+    array_walk_recursive($nodes, function ($item, $key) use (&$maxNavID) {
+        if ($key === 'navID') {
+            $maxNavID = max($maxNavID, $item);
+        }
+    });
+    _civalpa_civix_fixNavigationMenuItems($nodes, $maxNavID, null);
 }
 
-function _civalpa_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
-  $origKeys = array_keys($nodes);
-  foreach ($origKeys as $origKey) {
-    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
-      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+function _civalpa_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
+{
+    $origKeys = array_keys($nodes);
+    foreach ($origKeys as $origKey) {
+        if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== null) {
+            $nodes[$origKey]['attributes']['parentID'] = $parentID;
+        }
+      // If no navID, then assign navID and fix key.
+        if (!isset($nodes[$origKey]['attributes']['navID'])) {
+            $newKey = ++$maxNavID;
+            $nodes[$origKey]['attributes']['navID'] = $newKey;
+            $nodes[$newKey] = $nodes[$origKey];
+            unset($nodes[$origKey]);
+            $origKey = $newKey;
+        }
+        if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+            _civalpa_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+        }
     }
-    // If no navID, then assign navID and fix key.
-    if (!isset($nodes[$origKey]['attributes']['navID'])) {
-      $newKey = ++$maxNavID;
-      $nodes[$origKey]['attributes']['navID'] = $newKey;
-      $nodes[$newKey] = $nodes[$origKey];
-      unset($nodes[$origKey]);
-      $origKey = $newKey;
-    }
-    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
-      _civalpa_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
-    }
-  }
 }
 
 /**
@@ -458,11 +477,12 @@ function _civalpa_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
  */
-function _civalpa_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
+function _civalpa_civix_civicrm_alterSettingsFolders(&$metaDataFolders = null)
+{
+    $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
+    if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
+        $metaDataFolders[] = $settingsDir;
+    }
 }
 
 /**
@@ -472,6 +492,7 @@ function _civalpa_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
-function _civalpa_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, []);
+function _civalpa_civix_civicrm_entityTypes(&$entityTypes)
+{
+    $entityTypes = array_merge($entityTypes, []);
 }

--- a/civalpa.civix.php
+++ b/civalpa.civix.php
@@ -12,19 +12,19 @@ class CRM_Civalpa_ExtensionUtil
     const LONG_NAME = 'civalpa';
     const CLASS_PREFIX = 'CRM_Civalpa';
 
-  /**
-   * Translate a string using the extension's domain.
-   *
-   * If the extension doesn't have a specific translation
-   * for the string, fallback to the default translations.
-   *
-   * @param string $text
-   *   Canonical message text (generally en_US).
-   * @param array $params
-   * @return string
-   *   Translated text.
-   * @see ts
-   */
+    /**
+     * Translate a string using the extension's domain.
+     *
+     * If the extension doesn't have a specific translation
+     * for the string, fallback to the default translations.
+     *
+     * @param string $text
+     *   Canonical message text (generally en_US).
+     * @param array $params
+     * @return string
+     *   Translated text.
+     * @see ts
+     */
     public static function ts($text, $params = [])
     {
         if (!array_key_exists('domain', $params)) {
@@ -33,16 +33,16 @@ class CRM_Civalpa_ExtensionUtil
         return ts($text, $params);
     }
 
-  /**
-   * Get the URL of a resource file (in this extension).
-   *
-   * @param string|NULL $file
-   *   Ex: NULL.
-   *   Ex: 'css/foo.css'.
-   * @return string
-   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
-   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
-   */
+    /**
+     * Get the URL of a resource file (in this extension).
+     *
+     * @param string|NULL $file
+     *   Ex: NULL.
+     *   Ex: 'css/foo.css'.
+     * @return string
+     *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+     *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+     */
     public static function url($file = null)
     {
         if ($file === null) {
@@ -51,30 +51,30 @@ class CRM_Civalpa_ExtensionUtil
         return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
     }
 
-  /**
-   * Get the path of a resource file (in this extension).
-   *
-   * @param string|NULL $file
-   *   Ex: NULL.
-   *   Ex: 'css/foo.css'.
-   * @return string
-   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
-   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
-   */
+    /**
+     * Get the path of a resource file (in this extension).
+     *
+     * @param string|NULL $file
+     *   Ex: NULL.
+     *   Ex: 'css/foo.css'.
+     * @return string
+     *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+     *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+     */
     public static function path($file = null)
     {
-      // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+        // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
         return __DIR__ . ($file === null ? '' : (DIRECTORY_SEPARATOR . $file));
     }
 
-  /**
-   * Get the name of a class within this extension.
-   *
-   * @param string $suffix
-   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
-   * @return string
-   *   Ex: 'CRM_Foo_Page_HelloWorld'.
-   */
+    /**
+     * Get the name of a class within this extension.
+     *
+     * @param string $suffix
+     *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+     * @return string
+     *   Ex: 'CRM_Foo_Page_HelloWorld'.
+     */
     public static function findClass($suffix)
     {
         return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
@@ -400,7 +400,7 @@ function _civalpa_civix_glob($pattern)
  */
 function _civalpa_civix_insert_navigation_menu(&$menu, $path, $item)
 {
-  // If we are done going down the path, insert menu
+    // If we are done going down the path, insert menu
     if (empty($path)) {
         $menu[] = [
         'attributes' => array_merge([
@@ -410,7 +410,7 @@ function _civalpa_civix_insert_navigation_menu(&$menu, $path, $item)
         ];
         return true;
     } else {
-      // Find an recurse into the next level down
+        // Find an recurse into the next level down
         $found = false;
         $path = explode('/', $path);
         $first = array_shift($path);
@@ -458,7 +458,7 @@ function _civalpa_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
         if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== null) {
             $nodes[$origKey]['attributes']['parentID'] = $parentID;
         }
-      // If no navID, then assign navID and fix key.
+        // If no navID, then assign navID and fix key.
         if (!isset($nodes[$origKey]['attributes']['navID'])) {
             $newKey = ++$maxNavID;
             $nodes[$origKey]['attributes']['navID'] = $newKey;

--- a/civalpa.php
+++ b/civalpa.php
@@ -10,8 +10,9 @@ use CRM_Civalpa_ExtensionUtil as E;
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config/
  */
-function civalpa_civicrm_config(&$config) {
-  _civalpa_civix_civicrm_config($config);
+function civalpa_civicrm_config(&$config)
+{
+    _civalpa_civix_civicrm_config($config);
 }
 
 /**
@@ -19,8 +20,9 @@ function civalpa_civicrm_config(&$config) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
  */
-function civalpa_civicrm_xmlMenu(&$files) {
-  _civalpa_civix_civicrm_xmlMenu($files);
+function civalpa_civicrm_xmlMenu(&$files)
+{
+    _civalpa_civix_civicrm_xmlMenu($files);
 }
 
 /**
@@ -28,8 +30,9 @@ function civalpa_civicrm_xmlMenu(&$files) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
-function civalpa_civicrm_install() {
-  _civalpa_civix_civicrm_install();
+function civalpa_civicrm_install()
+{
+    _civalpa_civix_civicrm_install();
 }
 
 /**
@@ -37,8 +40,9 @@ function civalpa_civicrm_install() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
-function civalpa_civicrm_postInstall() {
-  _civalpa_civix_civicrm_postInstall();
+function civalpa_civicrm_postInstall()
+{
+    _civalpa_civix_civicrm_postInstall();
 }
 
 /**
@@ -46,8 +50,9 @@ function civalpa_civicrm_postInstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
-function civalpa_civicrm_uninstall() {
-  _civalpa_civix_civicrm_uninstall();
+function civalpa_civicrm_uninstall()
+{
+    _civalpa_civix_civicrm_uninstall();
 }
 
 /**
@@ -55,8 +60,9 @@ function civalpa_civicrm_uninstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
-function civalpa_civicrm_enable() {
-  _civalpa_civix_civicrm_enable();
+function civalpa_civicrm_enable()
+{
+    _civalpa_civix_civicrm_enable();
 }
 
 /**
@@ -64,8 +70,9 @@ function civalpa_civicrm_enable() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
  */
-function civalpa_civicrm_disable() {
-  _civalpa_civix_civicrm_disable();
+function civalpa_civicrm_disable()
+{
+    _civalpa_civix_civicrm_disable();
 }
 
 /**
@@ -73,8 +80,9 @@ function civalpa_civicrm_disable() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
-function civalpa_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  return _civalpa_civix_civicrm_upgrade($op, $queue);
+function civalpa_civicrm_upgrade($op, CRM_Queue_Queue $queue = null)
+{
+    return _civalpa_civix_civicrm_upgrade($op, $queue);
 }
 
 /**
@@ -85,8 +93,9 @@ function civalpa_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
  */
-function civalpa_civicrm_managed(&$entities) {
-  _civalpa_civix_civicrm_managed($entities);
+function civalpa_civicrm_managed(&$entities)
+{
+    _civalpa_civix_civicrm_managed($entities);
 }
 
 /**
@@ -98,8 +107,9 @@ function civalpa_civicrm_managed(&$entities) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
-function civalpa_civicrm_caseTypes(&$caseTypes) {
-  _civalpa_civix_civicrm_caseTypes($caseTypes);
+function civalpa_civicrm_caseTypes(&$caseTypes)
+{
+    _civalpa_civix_civicrm_caseTypes($caseTypes);
 }
 
 /**
@@ -112,8 +122,9 @@ function civalpa_civicrm_caseTypes(&$caseTypes) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
-function civalpa_civicrm_angularModules(&$angularModules) {
-  _civalpa_civix_civicrm_angularModules($angularModules);
+function civalpa_civicrm_angularModules(&$angularModules)
+{
+    _civalpa_civix_civicrm_angularModules($angularModules);
 }
 
 /**
@@ -121,8 +132,9 @@ function civalpa_civicrm_angularModules(&$angularModules) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
  */
-function civalpa_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _civalpa_civix_civicrm_alterSettingsFolders($metaDataFolders);
+function civalpa_civicrm_alterSettingsFolders(&$metaDataFolders = null)
+{
+    _civalpa_civix_civicrm_alterSettingsFolders($metaDataFolders);
 }
 
 /**
@@ -132,15 +144,17 @@ function civalpa_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
-function civalpa_civicrm_entityTypes(&$entityTypes) {
-  _civalpa_civix_civicrm_entityTypes($entityTypes);
+function civalpa_civicrm_entityTypes(&$entityTypes)
+{
+    _civalpa_civix_civicrm_entityTypes($entityTypes);
 }
 
 /**
  * Implements hook_civicrm_themes().
  */
-function civalpa_civicrm_themes(&$themes) {
-  _civalpa_civix_civicrm_themes($themes);
+function civalpa_civicrm_themes(&$themes)
+{
+    _civalpa_civix_civicrm_themes($themes);
 }
 
 // --- Functions below this ship commented out. Uncomment as required. ---
@@ -158,7 +172,8 @@ function civalpa_civicrm_themes(&$themes) {
 /**
  * Implements hook_civicrm_alterMailParams().
  */
-function civalpa_civicrm_alterMailParams(&$params, $context) {
+function civalpa_civicrm_alterMailParams(&$params, $context)
+{
     $cfg = new CRM_Civalpa_Config(E::SHORT_NAME);
     try {
         $cfg->load();
@@ -181,8 +196,11 @@ function civalpa_civicrm_alterMailParams(&$params, $context) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu
  */
-function civalpa_civicrm_navigationMenu(&$menu) {
-    _civalpa_civix_insert_navigation_menu($menu, "Administer/CiviMail",
+function civalpa_civicrm_navigationMenu(&$menu)
+{
+    _civalpa_civix_insert_navigation_menu(
+        $menu,
+        "Administer/CiviMail",
         [
             "label" => E::ts('CivAlPa Settings'),
             "name" => "civalpa_settings",

--- a/civalpa.php
+++ b/civalpa.php
@@ -3,6 +3,7 @@
 require_once 'civalpa.civix.php';
 // phpcs:disable
 use CRM_Civalpa_ExtensionUtil as E;
+
 // phpcs:enable
 
 /**

--- a/tests/phpunit/CRM/Civalpa/ConfigHeadlessTest.php
+++ b/tests/phpunit/CRM/Civalpa/ConfigHeadlessTest.php
@@ -10,26 +10,31 @@ use Civi\Test\TransactionalInterface;
  *
  * @group headless
  */
-class CRM_Civalpa_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class CRM_Civalpa_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
+{
 
-    public function setUpHeadless() {
+    public function setUpHeadless()
+    {
         return \Civi\Test::headless()
             ->installMe(__DIR__)
             ->apply();
     }
 
-    public function setUp(): void {
+    public function setUp(): void
+    {
         parent::setUp();
     }
 
-    public function tearDown(): void {
+    public function tearDown(): void
+    {
         parent::tearDown();
     }
 
     /**
      * It checks that the create function works well.
      */
-    public function testCreate() {
+    public function testCreate()
+    {
         $config = new CRM_Civalpa_Config("civalpa_test");
         self::assertTrue($config->create(), "Create config has to be successful.");
         $cfg = $config->get();
@@ -52,7 +57,8 @@ class CRM_Civalpa_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase impleme
     /**
      * It checks that the remove function works well.
      */
-    public function testRemove() {
+    public function testRemove()
+    {
         $config = new CRM_Civalpa_Config("civalpa_test");
         self::assertTrue($config->create(), "Create config has to be successful.");
         self::assertTrue($config->remove(), "Remove config has to be successful.");
@@ -61,7 +67,8 @@ class CRM_Civalpa_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase impleme
     /**
      * It checks that the get function works well.
      */
-    public function testGet() {
+    public function testGet()
+    {
         $config = new CRM_Civalpa_Config("civalpa_test");
         self::assertTrue($config->create(), "Create config has to be successful.");
         $cfg = $config->get();
@@ -87,7 +94,8 @@ class CRM_Civalpa_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase impleme
     /**
      * It checks that the get function works well.
      */
-    public function testUpdate() {
+    public function testUpdate()
+    {
         $config = new CRM_Civalpa_Config("civalpa_test");
         self::assertTrue($config->create(), "Create config has to be successful.");
         $cfg = $config->get();
@@ -100,7 +108,8 @@ class CRM_Civalpa_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase impleme
     /**
      * It checks that the get function works well.
      */
-    public function testLoad() {
+    public function testLoad()
+    {
         $config = new CRM_Civalpa_Config("civalpa_test");
         self::assertTrue($config->create(), "Create config has to be successful.");
         $cfg = $config->get();

--- a/tests/phpunit/CRM/Civalpa/ConfigHeadlessTest.php
+++ b/tests/phpunit/CRM/Civalpa/ConfigHeadlessTest.php
@@ -12,7 +12,6 @@ use Civi\Test\TransactionalInterface;
  */
 class CRM_Civalpa_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
 {
-
     public function setUpHeadless()
     {
         return \Civi\Test::headless()

--- a/tests/phpunit/CRM/Civalpa/ConfigTest.php
+++ b/tests/phpunit/CRM/Civalpa/ConfigTest.php
@@ -3,12 +3,14 @@
 /**
  * This is a generic test class for the extension (implemented with PHPUnit).
  */
-class CRM_Civalpa_ConfigTest extends \PHPUnit\Framework\TestCase {
+class CRM_Civalpa_ConfigTest extends \PHPUnit\Framework\TestCase
+{
 
     /**
      * The setup() method is executed before the test is executed (optional).
      */
-    public function setUp(): void {
+    public function setUp(): void
+    {
         parent::setUp();
     }
 
@@ -16,7 +18,8 @@ class CRM_Civalpa_ConfigTest extends \PHPUnit\Framework\TestCase {
      * The tearDown() method is executed after the test was executed (optional)
      * This can be used for cleanup.
      */
-    public function tearDown(): void {
+    public function tearDown(): void
+    {
         parent::tearDown();
     }
 
@@ -24,7 +27,8 @@ class CRM_Civalpa_ConfigTest extends \PHPUnit\Framework\TestCase {
      * Default configuration test case.
      *
      */
-    public function testConfigAfterConstructor() {
+    public function testConfigAfterConstructor()
+    {
         $config = new CRM_Civalpa_Config("civalpa_test");
         $cfg = $config->get();
         self::assertTrue(array_key_exists("debug-mode", $cfg), "debug-mode key is missing from the config.");
@@ -40,5 +44,4 @@ class CRM_Civalpa_ConfigTest extends \PHPUnit\Framework\TestCase {
         self::assertTrue(array_key_exists("value", $cfg["html-line-width"]), "html-line-width.value key is missing from the config.");
         self::assertEquals($cfg["html-line-width"]["value"], CRM_Civalpa_Config::DEFAULT_HTML_LINE_WIDTH, "Invalid html-line-width.value value.");
     }
-
 }

--- a/tests/phpunit/CRM/Civalpa/Form/CivalpaSettingsTest.php
+++ b/tests/phpunit/CRM/Civalpa/Form/CivalpaSettingsTest.php
@@ -12,7 +12,6 @@ use Civi\Test\TransactionalInterface;
  */
 class CRM_Civalpa_Form_CivalpaSettingsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
 {
-
     const TEST_SETTINGS = [
         "debug-mode" => true,
         "text-line-width" => [

--- a/tests/phpunit/CRM/Civalpa/Form/CivalpaSettingsTest.php
+++ b/tests/phpunit/CRM/Civalpa/Form/CivalpaSettingsTest.php
@@ -10,7 +10,8 @@ use Civi\Test\TransactionalInterface;
  *
  * @group headless
  */
-class CRM_Civalpa_Form_CivalpaSettingsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class CRM_Civalpa_Form_CivalpaSettingsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
+{
 
     const TEST_SETTINGS = [
         "debug-mode" => true,
@@ -23,21 +24,25 @@ class CRM_Civalpa_Form_CivalpaSettingsTest extends \PHPUnit\Framework\TestCase i
             "value" => 30,
         ],
     ];
-    public function setUpHeadless() {
+    public function setUpHeadless()
+    {
         return \Civi\Test::headless()
             ->installMe(__DIR__)
             ->apply();
     }
 
-    public function setUp(): void {
+    public function setUp(): void
+    {
         parent::setUp();
     }
 
-    public function tearDown(): void {
+    public function tearDown(): void
+    {
         parent::tearDown();
     }
 
-    private function setupTestConfig() {
+    private function setupTestConfig()
+    {
         $config = new CRM_Civalpa_Config(E::SHORT_NAME);
         self::assertTrue($config->update(self::TEST_SETTINGS), "Config update has to be successful.");
     }
@@ -47,7 +52,8 @@ class CRM_Civalpa_Form_CivalpaSettingsTest extends \PHPUnit\Framework\TestCase i
      * Setup test configuration then call the function.
      * It shouldn't throw exception.
      */
-    public function testPreProcessExistingConfig() {
+    public function testPreProcessExistingConfig()
+    {
         $this->setupTestConfig();
         $form = new CRM_Civalpa_Form_CivalpaSettings();
         try {
@@ -62,7 +68,8 @@ class CRM_Civalpa_Form_CivalpaSettingsTest extends \PHPUnit\Framework\TestCase i
      * Setup test configuration then call the function.
      * It should throw exception.
      */
-    public function testPreProcessMissingConfig() {
+    public function testPreProcessMissingConfig()
+    {
         $form = new CRM_Civalpa_Form_CivalpaSettings();
         $config = new CRM_Civalpa_Config(E::SHORT_NAME);
         $config->remove();
@@ -77,7 +84,8 @@ class CRM_Civalpa_Form_CivalpaSettingsTest extends \PHPUnit\Framework\TestCase i
      * It shouldn't throw exception.
      * The title should be set.
      */
-    public function testBuildQuickForm() {
+    public function testBuildQuickForm()
+    {
         $this->setupTestConfig();
         $form = new CRM_Civalpa_Form_CivalpaSettings();
         self::assertEmpty($form->preProcess(), "PreProcess supposed to be empty.");
@@ -93,7 +101,8 @@ class CRM_Civalpa_Form_CivalpaSettingsTest extends \PHPUnit\Framework\TestCase i
      * Add Rules test case.
      * It shouldn't throw exception.
      */
-    public function testAddRules() {
+    public function testAddRules()
+    {
         $this->setupTestConfig();
         $form = new CRM_Civalpa_Form_CivalpaSettings();
         try {
@@ -106,7 +115,8 @@ class CRM_Civalpa_Form_CivalpaSettingsTest extends \PHPUnit\Framework\TestCase i
     /**
      * Config Validator test cases.
      */
-    public function testConfigValidatorInvalid() {
+    public function testConfigValidatorInvalid()
+    {
         $testData = [
             [
                 "data" => [
@@ -147,7 +157,8 @@ class CRM_Civalpa_Form_CivalpaSettingsTest extends \PHPUnit\Framework\TestCase i
     /**
      * Post Process test case. The values are the same.
      */
-    public function testPostProcessNotChanged() {
+    public function testPostProcessNotChanged()
+    {
         $_POST["debugMode"] = self::TEST_SETTINGS["debug-mode"];
         $_POST["useTextRule"] = self::TEST_SETTINGS["text-line-width"]["use"];
         $_POST["textLineWidth"] = self::TEST_SETTINGS["text-line-width"]["value"];
@@ -166,7 +177,8 @@ class CRM_Civalpa_Form_CivalpaSettingsTest extends \PHPUnit\Framework\TestCase i
     /**
      * Post Process test case. The values are changed.
      */
-    public function testPostProcessChanged() {
+    public function testPostProcessChanged()
+    {
         $_POST["debugMode"] = !self::TEST_SETTINGS["debug-mode"];
         $_POST["useTextRule"] = self::TEST_SETTINGS["text-line-width"]["use"];
         $_POST["textLineWidth"] = self::TEST_SETTINGS["text-line-width"]["value"];
@@ -185,7 +197,8 @@ class CRM_Civalpa_Form_CivalpaSettingsTest extends \PHPUnit\Framework\TestCase i
     /**
      * Set Default Values test case.
      */
-    public function testSetDefaultValues() {
+    public function testSetDefaultValues()
+    {
         $expectedDefaults = [
             "debugMode" => self::TEST_SETTINGS["debug-mode"],
             "useTextRule" => self::TEST_SETTINGS["text-line-width"]["use"],

--- a/tests/phpunit/CRM/Civalpa/HeaderManipulatorTest.php
+++ b/tests/phpunit/CRM/Civalpa/HeaderManipulatorTest.php
@@ -3,292 +3,303 @@
 /**
  * This is a generic test class for the extension (implemented with PHPUnit).
  */
-class CRM_Civalpa_HeaderManipulatorTest extends \PHPUnit\Framework\TestCase {
+class CRM_Civalpa_HeaderManipulatorTest extends \PHPUnit\Framework\TestCase
+{
 
   /**
    * The setup() method is executed before the test is executed (optional).
    */
-  public function setUp(): void {
-    parent::setUp();
-  }
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
 
   /**
    * The tearDown() method is executed after the test was executed (optional)
    * This can be used for cleanup.
    */
-  public function tearDown(): void {
-    parent::tearDown();
-  }
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
 
   /**
    * Update test case.
    */
-  public function testUpdateSetEmptyDebugFlag() {
-    $config = [
-      "debug-mode" => true,
-      "text-line-width" => [
+    public function testUpdateSetEmptyDebugFlag()
+    {
+        $config = [
+        "debug-mode" => true,
+        "text-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "html-line-width" => [
+        ],
+        "html-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "headers" => [],
-    ];
-    $params = [
-      "text" => "test text",
-      "html" => "<p>test html</p>",
-    ];
-    $debugMessage = "";
-    CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
-    self::assertTrue(array_key_exists("headers", $params), "headers key is missing after header update.");
-    self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header is missing after header update.");
-    self::assertEquals("", $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be empty.");
-  }
-  public function testUpdateSetDebugFlag() {
-    $config = [
-      "debug-mode" => true,
-      "text-line-width" => [
+        ],
+        "headers" => [],
+        ];
+        $params = [
+        "text" => "test text",
+        "html" => "<p>test html</p>",
+        ];
+        $debugMessage = "";
+        CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
+        self::assertTrue(array_key_exists("headers", $params), "headers key is missing after header update.");
+        self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header is missing after header update.");
+        self::assertEquals("", $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be empty.");
+    }
+    public function testUpdateSetDebugFlag()
+    {
+        $config = [
+        "debug-mode" => true,
+        "text-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "html-line-width" => [
+        ],
+        "html-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "headers" => [],
-    ];
-    $params = [
-      "text" => "test text",
-      "html" => "<p>test html</p>",
-    ];
-    $debugMessage = "existingMessage,";
-    CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
-    self::assertTrue(array_key_exists("headers", $params), "headers key is missing after header update.");
-    self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header is missing after header update.");
-    self::assertEquals($debugMessage, $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be empty.");
-  }
-  public function testUpdateDebugModeOffNoDebugFlagNoHeaders() {
-    $config = [
-      "debug-mode" => false,
-      "text-line-width" => [
+        ],
+        "headers" => [],
+        ];
+        $params = [
+        "text" => "test text",
+        "html" => "<p>test html</p>",
+        ];
+        $debugMessage = "existingMessage,";
+        CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
+        self::assertTrue(array_key_exists("headers", $params), "headers key is missing after header update.");
+        self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header is missing after header update.");
+        self::assertEquals($debugMessage, $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be empty.");
+    }
+    public function testUpdateDebugModeOffNoDebugFlagNoHeaders()
+    {
+        $config = [
+        "debug-mode" => false,
+        "text-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "html-line-width" => [
+        ],
+        "html-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "headers" => [],
-    ];
-    $params = [
-      "text" => "test text",
-      "html" => "<p>test html</p>",
-    ];
-    $debugMessage = "existingError,";
-    CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
-    self::assertFalse(array_key_exists("headers", $params), "headers key is set after header update.");
-  }
-  public function testUpdateDebugModeOffNoDebugFlagWithHeaders() {
-    $config = [
-      "debug-mode" => false,
-      "text-line-width" => [
+        ],
+        "headers" => [],
+        ];
+        $params = [
+        "text" => "test text",
+        "html" => "<p>test html</p>",
+        ];
+        $debugMessage = "existingError,";
+        CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
+        self::assertFalse(array_key_exists("headers", $params), "headers key is set after header update.");
+    }
+    public function testUpdateDebugModeOffNoDebugFlagWithHeaders()
+    {
+        $config = [
+        "debug-mode" => false,
+        "text-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "html-line-width" => [
+        ],
+        "html-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "headers" => [],
-    ];
-    $params = [
-      "text" => "test text",
-      "html" => "<p>test html</p>",
-      "headers" => [
+        ],
+        "headers" => [],
+        ];
+        $params = [
+        "text" => "test text",
+        "html" => "<p>test html</p>",
+        "headers" => [
         "X-Something" => "1",
-      ],
-    ];
-    $debugMessage = "existingError,";
-    CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
-    self::assertTrue(array_key_exists("headers", $params), "headers key has to be set.");
-    self::assertFalse(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "headers shouldn't be set after header update.");
-  }
-  public function testUpdateDeleteFromParamHeader() {
-    $config = [
-      "debug-mode" => true,
-      "text-line-width" => [
+        ],
+        ];
+        $debugMessage = "existingError,";
+        CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
+        self::assertTrue(array_key_exists("headers", $params), "headers key has to be set.");
+        self::assertFalse(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "headers shouldn't be set after header update.");
+    }
+    public function testUpdateDeleteFromParamHeader()
+    {
+        $config = [
+        "debug-mode" => true,
+        "text-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "html-line-width" => [
+        ],
+        "html-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "headers" => [
+        ],
+        "headers" => [
         [
           "name" => "X-ToDelete",
           "unset" => true,
           "set" => false,
           "value" => "",
         ],
-      ],
-    ];
-    $params = [
-      "text" => "test text",
-      "html" => "<p>test html</p>",
-      "X-ToDelete" => "myValue",
-      "headers" => [
+        ],
+        ];
+        $params = [
+        "text" => "test text",
+        "html" => "<p>test html</p>",
+        "X-ToDelete" => "myValue",
+        "headers" => [
         "X-Something" => "1",
-      ],
-    ];
-    $debugMessage = "existingError,";
-    CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
-    self::assertTrue(array_key_exists("headers", $params), "headers key has to be set.");
-    self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header should be set after header update.");
-    self::assertEquals($debugMessage."headerUnset:X-ToDelete,", $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be expected value.");
-    self::assertFalse(array_key_exists("X-ToDelete", $params), "header shouldn't be set after header update.");
-  }
-  public function testUpdateDeleteFromHeader() {
-    $config = [
-      "debug-mode" => true,
-      "text-line-width" => [
+        ],
+        ];
+        $debugMessage = "existingError,";
+        CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
+        self::assertTrue(array_key_exists("headers", $params), "headers key has to be set.");
+        self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header should be set after header update.");
+        self::assertEquals($debugMessage."headerUnset:X-ToDelete,", $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be expected value.");
+        self::assertFalse(array_key_exists("X-ToDelete", $params), "header shouldn't be set after header update.");
+    }
+    public function testUpdateDeleteFromHeader()
+    {
+        $config = [
+        "debug-mode" => true,
+        "text-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "html-line-width" => [
+        ],
+        "html-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "headers" => [
+        ],
+        "headers" => [
         [
           "name" => "X-Something",
           "unset" => true,
           "set" => false,
           "value" => "",
         ],
-      ],
-    ];
-    $params = [
-      "text" => "test text",
-      "html" => "<p>test html</p>",
-      "X-ToDelete" => "myValue",
-      "headers" => [
+        ],
+        ];
+        $params = [
+        "text" => "test text",
+        "html" => "<p>test html</p>",
+        "X-ToDelete" => "myValue",
+        "headers" => [
         "X-Something" => "1",
-      ],
-    ];
-    $debugMessage = "existingError,";
-    CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
-    self::assertTrue(array_key_exists("headers", $params), "headers key has to be set.");
-    self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header should be set after header update.");
-    self::assertEquals($debugMessage."headerUnset:X-Something,", $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be expected value.");
-    self::assertFalse(array_key_exists("X-ToDelete", $params["headers"]), "header shouldn't be set after header update.");
-  }
-  public function testUpdateSetInParamHeader() {
-    $config = [
-      "debug-mode" => true,
-      "text-line-width" => [
+        ],
+        ];
+        $debugMessage = "existingError,";
+        CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
+        self::assertTrue(array_key_exists("headers", $params), "headers key has to be set.");
+        self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header should be set after header update.");
+        self::assertEquals($debugMessage."headerUnset:X-Something,", $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be expected value.");
+        self::assertFalse(array_key_exists("X-ToDelete", $params["headers"]), "header shouldn't be set after header update.");
+    }
+    public function testUpdateSetInParamHeader()
+    {
+        $config = [
+        "debug-mode" => true,
+        "text-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "html-line-width" => [
+        ],
+        "html-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "headers" => [
+        ],
+        "headers" => [
         [
           "name" => "X-ToDelete",
           "unset" => false,
           "set" => true,
           "value" => "Blah",
         ],
-      ],
-    ];
-    $params = [
-      "text" => "test text",
-      "html" => "<p>test html</p>",
-      "X-ToDelete" => "myValue",
-      "headers" => [
+        ],
+        ];
+        $params = [
+        "text" => "test text",
+        "html" => "<p>test html</p>",
+        "X-ToDelete" => "myValue",
+        "headers" => [
         "X-Something" => "1",
-      ],
-    ];
-    $debugMessage = "existingError,";
-    CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
-    self::assertTrue(array_key_exists("headers", $params), "headers key has to be set.");
-    self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header should be set after header update.");
-    self::assertEquals($debugMessage."headerSet:X-ToDelete,", $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be expected value.");
-    self::assertTrue(array_key_exists("X-ToDelete", $params), "header should be set after header update.");
-    self::assertEquals($config["headers"][0]["value"], $params["X-ToDelete"], "Header value supposed to be expected value.");
-  }
-  public function testUpdateSetInHeader() {
-    $config = [
-      "debug-mode" => true,
-      "text-line-width" => [
+        ],
+        ];
+        $debugMessage = "existingError,";
+        CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
+        self::assertTrue(array_key_exists("headers", $params), "headers key has to be set.");
+        self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header should be set after header update.");
+        self::assertEquals($debugMessage."headerSet:X-ToDelete,", $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be expected value.");
+        self::assertTrue(array_key_exists("X-ToDelete", $params), "header should be set after header update.");
+        self::assertEquals($config["headers"][0]["value"], $params["X-ToDelete"], "Header value supposed to be expected value.");
+    }
+    public function testUpdateSetInHeader()
+    {
+        $config = [
+        "debug-mode" => true,
+        "text-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "html-line-width" => [
+        ],
+        "html-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "headers" => [
+        ],
+        "headers" => [
         [
           "name" => "X-Something",
           "unset" => false,
           "set" => true,
           "value" => "Blah",
         ],
-      ],
-    ];
-    $params = [
-      "text" => "test text",
-      "html" => "<p>test html</p>",
-      "X-ToDelete" => "myValue",
-    ];
-    $debugMessage = "existingError,";
-    CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
-    self::assertTrue(array_key_exists("headers", $params), "headers key has to be set.");
-    self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header should be set after header update.");
-    self::assertEquals($debugMessage."headerSet:X-Something,", $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be expected value.");
-    self::assertTrue(array_key_exists("X-Something", $params["headers"]), "header shouldn't be set after header update.");
-    self::assertEquals($config["headers"][0]["value"], $params["headers"]["X-Something"], "Header value supposed to be expected value.");
-  }
-  public function testUpdateUpdateInHeader() {
-    $config = [
-      "debug-mode" => true,
-      "text-line-width" => [
+        ],
+        ];
+        $params = [
+        "text" => "test text",
+        "html" => "<p>test html</p>",
+        "X-ToDelete" => "myValue",
+        ];
+        $debugMessage = "existingError,";
+        CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
+        self::assertTrue(array_key_exists("headers", $params), "headers key has to be set.");
+        self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header should be set after header update.");
+        self::assertEquals($debugMessage."headerSet:X-Something,", $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be expected value.");
+        self::assertTrue(array_key_exists("X-Something", $params["headers"]), "header shouldn't be set after header update.");
+        self::assertEquals($config["headers"][0]["value"], $params["headers"]["X-Something"], "Header value supposed to be expected value.");
+    }
+    public function testUpdateUpdateInHeader()
+    {
+        $config = [
+        "debug-mode" => true,
+        "text-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "html-line-width" => [
+        ],
+        "html-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "headers" => [
+        ],
+        "headers" => [
         [
           "name" => "X-Something",
           "unset" => false,
           "set" => true,
           "value" => "Blah",
         ],
-      ],
-    ];
-    $params = [
-      "text" => "test text",
-      "html" => "<p>test html</p>",
-      "X-ToDelete" => "myValue",
-      "headers" => [
+        ],
+        ];
+        $params = [
+        "text" => "test text",
+        "html" => "<p>test html</p>",
+        "X-ToDelete" => "myValue",
+        "headers" => [
         "X-Something" => "1",
-      ],
-    ];
-    $debugMessage = "existingError,";
-    CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
-    self::assertTrue(array_key_exists("headers", $params), "headers key has to be set.");
-    self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header should be set after header update.");
-    self::assertEquals($debugMessage."headerSet:X-Something,", $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be expected value.");
-    self::assertTrue(array_key_exists("X-Something", $params["headers"]), "header shouldn't be set after header update.");
-    self::assertEquals($config["headers"][0]["value"], $params["headers"]["X-Something"], "Header value supposed to be expected value.");
-  }
-
+        ],
+        ];
+        $debugMessage = "existingError,";
+        CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
+        self::assertTrue(array_key_exists("headers", $params), "headers key has to be set.");
+        self::assertTrue(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header should be set after header update.");
+        self::assertEquals($debugMessage."headerSet:X-Something,", $params["headers"]["X-CIVALPA-DEBUG"], "Header value supposed to be expected value.");
+        self::assertTrue(array_key_exists("X-Something", $params["headers"]), "header shouldn't be set after header update.");
+        self::assertEquals($config["headers"][0]["value"], $params["headers"]["X-Something"], "Header value supposed to be expected value.");
+    }
 }

--- a/tests/phpunit/CRM/Civalpa/HeaderManipulatorTest.php
+++ b/tests/phpunit/CRM/Civalpa/HeaderManipulatorTest.php
@@ -14,18 +14,18 @@ class CRM_Civalpa_HeaderManipulatorTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
     }
 
-  /**
-   * The tearDown() method is executed after the test was executed (optional)
-   * This can be used for cleanup.
-   */
+    /**
+     * The tearDown() method is executed after the test was executed (optional)
+     * This can be used for cleanup.
+     */
     public function tearDown(): void
     {
         parent::tearDown();
     }
 
-  /**
-   * Update test case.
-   */
+    /**
+     * Update test case.
+     */
     public function testUpdateSetEmptyDebugFlag()
     {
         $config = [

--- a/tests/phpunit/CRM/Civalpa/TextFormatterTest.php
+++ b/tests/phpunit/CRM/Civalpa/TextFormatterTest.php
@@ -3,69 +3,72 @@
 /**
  * This is a generic test class for the extension (implemented with PHPUnit).
  */
-class CRM_Civalpa_TextFormatterTest extends \PHPUnit\Framework\TestCase {
+class CRM_Civalpa_TextFormatterTest extends \PHPUnit\Framework\TestCase
+{
 
   /**
    * The setup() method is executed before the test is executed (optional).
    */
-  public function setUp(): void {
-    parent::setUp();
-  }
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
 
   /**
    * The tearDown() method is executed after the test was executed (optional)
    * This can be used for cleanup.
    */
-  public function tearDown(): void {
-    parent::tearDown();
-  }
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
 
   /**
    * format test cases.
    */
-  public function testFormat() {
-    $config = [
-      "debug-mode" => true,
-      "text-line-width" => [
+    public function testFormat()
+    {
+        $config = [
+        "debug-mode" => true,
+        "text-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-      "html-line-width" => [
+        ],
+        "html-line-width" => [
         "use" => true,
         "value" => 50,
-      ],
-    ];
-    // empty values for text and html. config has to be unchanged, debug has to be empty.
-    $emptyValue = "";
-    $result = CRM_Civalpa_TextFormatter::format($config, $emptyValue, $emptyValue);
-    self::assertTrue(array_key_exists("html", $result), "html key is missing from format result.");
-    self::assertEquals($result["html"], $emptyValue, "Invalid html in format result.");
-    self::assertTrue(array_key_exists("text", $result), "text key is missing from format result.");
-    self::assertEquals($result["text"], $emptyValue, "Invalid text in format result.");
-    self::assertTrue(array_key_exists("debug", $result), "debug key is missing from format result.");
-    self::assertEquals($result["debug"], $emptyValue, "Invalid debug in format result.");
-    // short values for text and html. config has to be unchanged, debug has to be empty.
-    $shortText = "Something sort text.";
-    $shortHtml = "<p>".$shortText."</p>";
-    $result = CRM_Civalpa_TextFormatter::format($config, $shortText, $shortHtml);
-    self::assertTrue(array_key_exists("html", $result), "html key is missing from format result.");
-    self::assertEquals($result["html"], $shortHtml, "Invalid html in format result.");
-    self::assertTrue(array_key_exists("text", $result), "text key is missing from format result.");
-    self::assertEquals($result["text"], $shortText, "Invalid text in format result.");
-    self::assertTrue(array_key_exists("debug", $result), "debug key is missing from format result.");
-    self::assertEquals($result["debug"], $emptyValue, "Invalid debug in format result.");
-    // long values for text and html. config has to be changed, debug has to be text and html.
-    $longText = "Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép.";
-    $expectedLongText = "Something sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.\nSomething sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.\nSomething sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.";
-    $longHtml = "<p>".$longText."</p>";
-    $expectedLongHtml = "<p>Something sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.\nSomething sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.\nSomething sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.</p>";
-    $result = CRM_Civalpa_TextFormatter::format($config, $longText, $longHtml);
-    self::assertTrue(array_key_exists("html", $result), "html key is missing from format result.");
-    self::assertEquals($result["html"], $expectedLongHtml, "Invalid html in format result.");
-    self::assertTrue(array_key_exists("text", $result), "text key is missing from format result.");
-    self::assertEquals($result["text"], $expectedLongText, "Invalid text in format result.");
-    self::assertTrue(array_key_exists("debug", $result), "debug key is missing from format result.");
-    self::assertEquals($result["debug"], "textWrap,htmlWrap,", "Invalid debug in format result.");
-  }
-
+        ],
+        ];
+      // empty values for text and html. config has to be unchanged, debug has to be empty.
+        $emptyValue = "";
+        $result = CRM_Civalpa_TextFormatter::format($config, $emptyValue, $emptyValue);
+        self::assertTrue(array_key_exists("html", $result), "html key is missing from format result.");
+        self::assertEquals($result["html"], $emptyValue, "Invalid html in format result.");
+        self::assertTrue(array_key_exists("text", $result), "text key is missing from format result.");
+        self::assertEquals($result["text"], $emptyValue, "Invalid text in format result.");
+        self::assertTrue(array_key_exists("debug", $result), "debug key is missing from format result.");
+        self::assertEquals($result["debug"], $emptyValue, "Invalid debug in format result.");
+      // short values for text and html. config has to be unchanged, debug has to be empty.
+        $shortText = "Something sort text.";
+        $shortHtml = "<p>".$shortText."</p>";
+        $result = CRM_Civalpa_TextFormatter::format($config, $shortText, $shortHtml);
+        self::assertTrue(array_key_exists("html", $result), "html key is missing from format result.");
+        self::assertEquals($result["html"], $shortHtml, "Invalid html in format result.");
+        self::assertTrue(array_key_exists("text", $result), "text key is missing from format result.");
+        self::assertEquals($result["text"], $shortText, "Invalid text in format result.");
+        self::assertTrue(array_key_exists("debug", $result), "debug key is missing from format result.");
+        self::assertEquals($result["debug"], $emptyValue, "Invalid debug in format result.");
+      // long values for text and html. config has to be changed, debug has to be text and html.
+        $longText = "Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép.";
+        $expectedLongText = "Something sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.\nSomething sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.\nSomething sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.";
+        $longHtml = "<p>".$longText."</p>";
+        $expectedLongHtml = "<p>Something sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.\nSomething sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.\nSomething sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.</p>";
+        $result = CRM_Civalpa_TextFormatter::format($config, $longText, $longHtml);
+        self::assertTrue(array_key_exists("html", $result), "html key is missing from format result.");
+        self::assertEquals($result["html"], $expectedLongHtml, "Invalid html in format result.");
+        self::assertTrue(array_key_exists("text", $result), "text key is missing from format result.");
+        self::assertEquals($result["text"], $expectedLongText, "Invalid text in format result.");
+        self::assertTrue(array_key_exists("debug", $result), "debug key is missing from format result.");
+        self::assertEquals($result["debug"], "textWrap,htmlWrap,", "Invalid debug in format result.");
+    }
 }

--- a/tests/phpunit/CRM/Civalpa/TextFormatterTest.php
+++ b/tests/phpunit/CRM/Civalpa/TextFormatterTest.php
@@ -14,18 +14,18 @@ class CRM_Civalpa_TextFormatterTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
     }
 
-  /**
-   * The tearDown() method is executed after the test was executed (optional)
-   * This can be used for cleanup.
-   */
+    /**
+     * The tearDown() method is executed after the test was executed (optional)
+     * This can be used for cleanup.
+     */
     public function tearDown(): void
     {
         parent::tearDown();
     }
 
-  /**
-   * format test cases.
-   */
+    /**
+     * format test cases.
+     */
     public function testFormat()
     {
         $config = [
@@ -39,7 +39,7 @@ class CRM_Civalpa_TextFormatterTest extends \PHPUnit\Framework\TestCase
         "value" => 50,
         ],
         ];
-      // empty values for text and html. config has to be unchanged, debug has to be empty.
+        // empty values for text and html. config has to be unchanged, debug has to be empty.
         $emptyValue = "";
         $result = CRM_Civalpa_TextFormatter::format($config, $emptyValue, $emptyValue);
         self::assertTrue(array_key_exists("html", $result), "html key is missing from format result.");
@@ -48,7 +48,7 @@ class CRM_Civalpa_TextFormatterTest extends \PHPUnit\Framework\TestCase
         self::assertEquals($result["text"], $emptyValue, "Invalid text in format result.");
         self::assertTrue(array_key_exists("debug", $result), "debug key is missing from format result.");
         self::assertEquals($result["debug"], $emptyValue, "Invalid debug in format result.");
-      // short values for text and html. config has to be unchanged, debug has to be empty.
+        // short values for text and html. config has to be unchanged, debug has to be empty.
         $shortText = "Something sort text.";
         $shortHtml = "<p>".$shortText."</p>";
         $result = CRM_Civalpa_TextFormatter::format($config, $shortText, $shortHtml);
@@ -58,7 +58,7 @@ class CRM_Civalpa_TextFormatterTest extends \PHPUnit\Framework\TestCase
         self::assertEquals($result["text"], $shortText, "Invalid text in format result.");
         self::assertTrue(array_key_exists("debug", $result), "debug key is missing from format result.");
         self::assertEquals($result["debug"], $emptyValue, "Invalid debug in format result.");
-      // long values for text and html. config has to be changed, debug has to be text and html.
+        // long values for text and html. config has to be changed, debug has to be text and html.
         $longText = "Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép. Something sort text like árvíztűrőtükörfúrógép.";
         $expectedLongText = "Something sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.\nSomething sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.\nSomething sort text like\nárvíztűrőtükörfúrógép. Something sort\ntext like árvíztűrőtükörfúrógép.";
         $longHtml = "<p>".$longText."</p>";

--- a/tests/phpunit/CRM/Civalpa/UpgraderHeadlessTest.php
+++ b/tests/phpunit/CRM/Civalpa/UpgraderHeadlessTest.php
@@ -10,26 +10,31 @@ use Civi\Test\TransactionalInterface;
  *
  * @group headless
  */
-class CRM_Civalpa_UpgraderHeadlessTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class CRM_Civalpa_UpgraderHeadlessTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
+{
 
-    public function setUpHeadless() {
+    public function setUpHeadless()
+    {
         return \Civi\Test::headless()
             ->installMe(__DIR__)
             ->apply();
     }
 
-    public function setUp():void {
+    public function setUp():void
+    {
         parent::setUp();
     }
 
-    public function tearDown(): void {
+    public function tearDown(): void
+    {
         parent::tearDown();
     }
 
     /**
      * Test the install process.
      */
-    public function testInstall() {
+    public function testInstall()
+    {
         $installer = new CRM_Civalpa_Upgrader("civalpa_test", ".");
         try {
             $this->assertEmpty($installer->install());
@@ -41,7 +46,8 @@ class CRM_Civalpa_UpgraderHeadlessTest extends \PHPUnit\Framework\TestCase imple
     /**
      * Test the uninstall process.
      */
-    public function testUninstall() {
+    public function testUninstall()
+    {
         $installer = new CRM_Civalpa_Upgrader("civalpa_test", ".");
         $this->assertEmpty($installer->install());
         try {
@@ -50,5 +56,4 @@ class CRM_Civalpa_UpgraderHeadlessTest extends \PHPUnit\Framework\TestCase imple
             $this->fail("Should not throw exception.");
         }
     }
-
 }

--- a/tests/phpunit/CRM/Civalpa/UpgraderHeadlessTest.php
+++ b/tests/phpunit/CRM/Civalpa/UpgraderHeadlessTest.php
@@ -12,7 +12,6 @@ use Civi\Test\TransactionalInterface;
  */
 class CRM_Civalpa_UpgraderHeadlessTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface
 {
-
     public function setUpHeadless()
     {
         return \Civi\Test::headless()

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -25,39 +25,40 @@ $loader->register();
  * @throws \RuntimeException
  *   If the command terminates abnormally.
  */
-function cv($cmd, $decode = 'json') {
-  $cmd = 'cv ' . $cmd;
-  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
-  $oldOutput = getenv('CV_OUTPUT');
-  putenv("CV_OUTPUT=json");
+function cv($cmd, $decode = 'json')
+{
+    $cmd = 'cv ' . $cmd;
+    $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+    $oldOutput = getenv('CV_OUTPUT');
+    putenv("CV_OUTPUT=json");
 
   // Execute `cv` in the original folder. This is a work-around for
   // phpunit/codeception, which seem to manipulate PWD.
-  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+    $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
 
-  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
-  putenv("CV_OUTPUT=$oldOutput");
-  fclose($pipes[0]);
-  $result = stream_get_contents($pipes[1]);
-  fclose($pipes[1]);
-  if (proc_close($process) !== 0) {
-    throw new RuntimeException("Command failed ($cmd):\n$result");
-  }
-  switch ($decode) {
-    case 'raw':
-      return $result;
+    $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+    putenv("CV_OUTPUT=$oldOutput");
+    fclose($pipes[0]);
+    $result = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+    if (proc_close($process) !== 0) {
+        throw new RuntimeException("Command failed ($cmd):\n$result");
+    }
+    switch ($decode) {
+        case 'raw':
+            return $result;
 
-    case 'phpcode':
-      // If the last output is /*PHPCODE*/, then we managed to complete execution.
-      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
-        throw new \RuntimeException("Command failed ($cmd):\n$result");
-      }
-      return $result;
+        case 'phpcode':
+          // If the last output is /*PHPCODE*/, then we managed to complete execution.
+            if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+                throw new \RuntimeException("Command failed ($cmd):\n$result");
+            }
+            return $result;
 
-    case 'json':
-      return json_decode($result, 1);
+        case 'json':
+            return json_decode($result, 1);
 
-    default:
-      throw new RuntimeException("Bad decoder format ($decode)");
-  }
+        default:
+            throw new RuntimeException("Bad decoder format ($decode)");
+    }
 }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -32,8 +32,8 @@ function cv($cmd, $decode = 'json')
     $oldOutput = getenv('CV_OUTPUT');
     putenv("CV_OUTPUT=json");
 
-  // Execute `cv` in the original folder. This is a work-around for
-  // phpunit/codeception, which seem to manipulate PWD.
+    // Execute `cv` in the original folder. This is a work-around for
+    // phpunit/codeception, which seem to manipulate PWD.
     $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
 
     $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);


### PR DESCRIPTION
Forma files with `phpcbf --standard=PSR2 *` command.
Further format with `php-cs-fixer fix . --rules=@PSR2` command. As it turned out, this tool is more clever than the phpbcf. It makes fixes in the comments, docblocks also.

Manual changes were not done.