### PR TITLE
Header manipulation step has to be skipped if the config is missing

### DIFF
--- a/CRM/Civalpa/HeaderManipulator.php
+++ b/CRM/Civalpa/HeaderManipulator.php
@@ -4,6 +4,10 @@ class CRM_Civalpa_HeaderManipulator
 {
     public static function update(&$params, array $config, string $debugMessage = "")
     {
+        if (!isset($config['headers'])) {
+            Civi::log()->error('Civalpa | Header config is missing. Configdump: '.var_export($config, true));
+            return;
+        }
         foreach ($config["headers"] as $headerConfig) {
             $headerName = $headerConfig["name"];
             if ($headerConfig["unset"]) {

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The extension is licensed under [AGPL-3.0](LICENSE.txt).
 ## Requirements
 
 * PHP v7.2+
-* CiviCRM 5.29
+* CiviCRM 5.29+
+* [RC-Base](https://github.com/reflexive-communications/rc-base) v0.8.1+
 
 ## Installation (Web UI)
 

--- a/civalpa.php
+++ b/civalpa.php
@@ -194,6 +194,7 @@ function civalpa_civicrm_alterMailParams(&$params, $context)
     $result = CRM_Civalpa_TextFormatter::format($config, $params["text"], $params["html"]);
     $params["text"] = $result["text"];
     $params["html"] = $result["html"];
+    Civi::log()->info('Civalpa | Header manipulation in the following context: '.$context);
     CRM_Civalpa_HeaderManipulator::update($params, $config, $result["debug"]);
 }
 

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/reflexive-communications/civalpa/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2021-04-14</releaseDate>
-  <version>0.3.1</version>
+  <releaseDate>2021-07-07</releaseDate>
+  <version>0.3.2</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.0</ver>
@@ -23,7 +23,7 @@
   <requires>
     <ext>rc-base</ext>
   </requires>
-  <comments>This is a new, undeveloped module</comments>
+  <comments>Civimail Alter mail Params extension. It can be used for wrapping the text, html strings, also manipulating headers.</comments>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>

--- a/tests/phpunit/CRM/Civalpa/ConfigHeadlessTest.php
+++ b/tests/phpunit/CRM/Civalpa/ConfigHeadlessTest.php
@@ -19,6 +19,34 @@ class CRM_Civalpa_ConfigHeadlessTest extends \PHPUnit\Framework\TestCase impleme
             ->apply();
     }
 
+    /**
+     * Apply a forced rebuild of DB, thus
+     * create a clean DB before running tests
+     *
+     * @throws \CRM_Extension_Exception_ParseException
+     */
+    public static function setUpBeforeClass(): void
+    {
+        // Resets DB and install depended extension
+        \Civi\Test::headless()
+            ->install('rc-base')
+            ->installMe(__DIR__)
+            ->apply(true);
+    }
+
+    /**
+     * Create a clean DB before running tests
+     *
+     * @throws CRM_Extension_Exception_ParseException
+     */
+    public static function tearDownAfterClass(): void
+    {
+        \Civi\Test::headless()
+            ->uninstallMe(__DIR__)
+            ->uninstall('rc-base')
+            ->apply(true);
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/phpunit/CRM/Civalpa/HeaderManipulatorTest.php
+++ b/tests/phpunit/CRM/Civalpa/HeaderManipulatorTest.php
@@ -302,4 +302,22 @@ class CRM_Civalpa_HeaderManipulatorTest extends \PHPUnit\Framework\TestCase
         self::assertTrue(array_key_exists("X-Something", $params["headers"]), "header shouldn't be set after header update.");
         self::assertEquals($config["headers"][0]["value"], $params["headers"]["X-Something"], "Header value supposed to be expected value.");
     }
+    public function testUpdateMissingConfig()
+    {
+        $config = [];
+        $params = [
+            "text" => "test text",
+            "html" => "<p>test html</p>",
+            "X-ToDelete" => "myValue",
+            "headers" => [
+                "X-Something" => "1",
+            ],
+        ];
+        $debugMessage = "existingError,";
+        CRM_Civalpa_HeaderManipulator::update($params, $config, $debugMessage);
+        self::assertTrue(array_key_exists("headers", $params), "headers key has to be set.");
+        self::assertFalse(array_key_exists("X-CIVALPA-DEBUG", $params["headers"]), "X-CIVALPA-DEBUG header shouldn't be set if the config is missing.");
+        self::assertTrue(array_key_exists("X-Something", $params["headers"]), "header shouldn't be set after header update.");
+        self::assertEquals("1", $params["headers"]["X-Something"], "Header value supposed to be expected value.");
+    }
 }

--- a/tests/phpunit/CRM/Civalpa/UpgraderHeadlessTest.php
+++ b/tests/phpunit/CRM/Civalpa/UpgraderHeadlessTest.php
@@ -19,14 +19,19 @@ class CRM_Civalpa_UpgraderHeadlessTest extends \PHPUnit\Framework\TestCase imple
             ->apply();
     }
 
-    public function setUp():void
+    /**
+     * Apply a forced rebuild of DB, thus
+     * create a clean DB before running tests
+     *
+     * @throws \CRM_Extension_Exception_ParseException
+     */
+    public static function setUpBeforeClass(): void
     {
-        parent::setUp();
-    }
-
-    public function tearDown(): void
-    {
-        parent::tearDown();
+        // Resets DB and install depended extension
+        \Civi\Test::headless()
+            ->install('rc-base')
+            ->installMe(__DIR__)
+            ->apply(true);
     }
 
     /**
@@ -38,7 +43,18 @@ class CRM_Civalpa_UpgraderHeadlessTest extends \PHPUnit\Framework\TestCase imple
     {
         \Civi\Test::headless()
             ->uninstallMe(__DIR__)
+            ->uninstall('rc-base')
             ->apply(true);
+    }
+
+    public function setUp():void
+    {
+        parent::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
     }
 
     /**


### PR DESCRIPTION
For some reason, error message appears on the form after various actions. Currently i beleive the issue appears
when an email sending is happening in the background. It is hard to track down, because i can't reproduce it on
my environment, so it contains an info log about the context also. My mailing setup might be different.


### Todo

- [x] Update testcases
- [x] Version and release date
- [x] Documentation